### PR TITLE
RunToolsOutputParameter.ToolOutput' initializer is inaccessible due to 'internal' protection level

### DIFF
--- a/Sources/OpenAI/Public/Parameters/Runs/RunToolsOutputParameter.swift
+++ b/Sources/OpenAI/Public/Parameters/Runs/RunToolsOutputParameter.swift
@@ -24,10 +24,24 @@ public struct RunToolsOutputParameter: Encodable {
          case toolCallId = "tool_call_id"
          case output
       }
+      
+      public init(
+         toolCallId: String?,
+         output: String?)
+      {
+         self.toolCallId = toolCallId
+         self.output = output
+      }
    }
    
    enum CodingKeys: String, CodingKey {
       case toolOutputs = "tool_outputs"
+   }
+   
+   public init(
+      toolOutputs: [ToolOutput])
+   {
+      self.toolOutputs = toolOutputs
    }
 }
 


### PR DESCRIPTION
RunToolsOutputParameter.ToolOutput' initializer is inaccessible due to 'internal' protection level