### PR TITLE
Made the sample app reference local SPM package

### DIFF
--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample.xcodeproj/project.pbxproj
@@ -3,16 +3,16 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0DEE5DC12BB40643004894AD /* SwiftOpenAI in Frameworks */ = {isa = PBXBuildFile; productRef = 0DEE5DC02BB40643004894AD /* SwiftOpenAI */; };
 		7B1268052B08246400400694 /* AssistantConfigurationDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1268042B08246400400694 /* AssistantConfigurationDemoView.swift */; };
 		7B1268072B08247C00400694 /* AssistantConfigurationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1268062B08247C00400694 /* AssistantConfigurationProvider.swift */; };
 		7B3DDCC52BAAA722004B5C96 /* AssistantsListDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3DDCC42BAAA722004B5C96 /* AssistantsListDemoView.swift */; };
 		7B3DDCC72BAAAD34004B5C96 /* AssistantThreadConfigurationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3DDCC62BAAAD34004B5C96 /* AssistantThreadConfigurationProvider.swift */; };
 		7B3DDCC92BAAAF96004B5C96 /* AssistantStreamDemoScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3DDCC82BAAAF96004B5C96 /* AssistantStreamDemoScreen.swift */; };
-		7B3DDCD22BAE2718004B5C96 /* SwiftOpenAI in Frameworks */ = {isa = PBXBuildFile; productRef = 7B3DDCD12BAE2718004B5C96 /* SwiftOpenAI */; };
 		7B436B962AE24A04003CE281 /* OptionsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B436B952AE24A04003CE281 /* OptionsListView.swift */; };
 		7B436B992AE25052003CE281 /* ContentLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B436B982AE25052003CE281 /* ContentLoader.swift */; };
 		7B436B9B2AE25094003CE281 /* narcos.m4a in Resources */ = {isa = PBXBuildFile; fileRef = 7B436B9A2AE25093003CE281 /* narcos.m4a */; };
@@ -137,7 +137,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7B3DDCD22BAE2718004B5C96 /* SwiftOpenAI in Frameworks */,
+				0DEE5DC12BB40643004894AD /* SwiftOpenAI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -426,7 +426,7 @@
 			);
 			name = SwiftOpenAIExample;
 			packageProductDependencies = (
-				7B3DDCD12BAE2718004B5C96 /* SwiftOpenAI */,
+				0DEE5DC02BB40643004894AD /* SwiftOpenAI */,
 			);
 			productName = SwiftOpenAIExample;
 			productReference = 7BA788C92AE23A48008825D5 /* SwiftOpenAIExample.app */;
@@ -501,7 +501,7 @@
 			);
 			mainGroup = 7BA788C02AE23A48008825D5;
 			packageReferences = (
-				7B3DDCD02BAE2718004B5C96 /* XCRemoteSwiftPackageReference "SwiftOpenAI" */,
+				0DEE5DBF2BB40643004894AD /* XCLocalSwiftPackageReference "../.." */,
 			);
 			productRefGroup = 7BA788CA2AE23A48008825D5 /* Products */;
 			projectDirPath = "";
@@ -946,21 +946,16 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		7B3DDCD02BAE2718004B5C96 /* XCRemoteSwiftPackageReference "SwiftOpenAI" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/jamesrochabrun/SwiftOpenAI";
-			requirement = {
-				branch = main;
-				kind = branch;
-			};
+/* Begin XCLocalSwiftPackageReference section */
+		0DEE5DBF2BB40643004894AD /* XCLocalSwiftPackageReference "../.." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../..;
 		};
-/* End XCRemoteSwiftPackageReference section */
+/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		7B3DDCD12BAE2718004B5C96 /* SwiftOpenAI */ = {
+		0DEE5DC02BB40643004894AD /* SwiftOpenAI */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 7B3DDCD02BAE2718004B5C96 /* XCRemoteSwiftPackageReference "SwiftOpenAI" */;
 			productName = SwiftOpenAI;
 		};
 /* End XCSwiftPackageProductDependency section */


### PR DESCRIPTION
The sample project at `Examples/SwiftOpenAIExample/SwiftOpenAIExample.xcodeproj` now references the local SPM package at the root of the repo. This makes it easier to make changes to the SPM package while working within the sample project. There are two major differences:

1. The dependency on SwiftOpenAI is added using a 'local package' at `File > Add Package Dependencies`:

![Screenshot 2024-03-27 at 00 52 11](https://github.com/jamesrochabrun/SwiftOpenAI/assets/35940/aa4cf7b4-4f8a-4bb9-b37a-064a04b86165)


2. Occasionally Xcode stops tracking the changes accurately when modifying SwiftOpenAI from within the SwiftOpenAIExample project. If that happens to you, go to `File > Packages > Reset Package Caches`