### PR TITLE
Added AI Proxy support to the sample app

### DIFF
--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		0DEE5DC12BB40643004894AD /* SwiftOpenAI in Frameworks */ = {isa = PBXBuildFile; productRef = 0DEE5DC02BB40643004894AD /* SwiftOpenAI */; };
+		0DF957842BB53BEF00DD2013 /* ServiceSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF957832BB53BEF00DD2013 /* ServiceSelectionView.swift */; };
+		0DF957862BB543F100DD2013 /* AIProxyIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF957852BB543F100DD2013 /* AIProxyIntroView.swift */; };
 		7B1268052B08246400400694 /* AssistantConfigurationDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1268042B08246400400694 /* AssistantConfigurationDemoView.swift */; };
 		7B1268072B08247C00400694 /* AssistantConfigurationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1268062B08247C00400694 /* AssistantConfigurationProvider.swift */; };
 		7B3DDCC52BAAA722004B5C96 /* AssistantsListDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3DDCC42BAAA722004B5C96 /* AssistantsListDemoView.swift */; };
@@ -77,6 +79,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0DF957832BB53BEF00DD2013 /* ServiceSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceSelectionView.swift; sourceTree = "<group>"; };
+		0DF957852BB543F100DD2013 /* AIProxyIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProxyIntroView.swift; sourceTree = "<group>"; };
 		7B1268042B08246400400694 /* AssistantConfigurationDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistantConfigurationDemoView.swift; sourceTree = "<group>"; };
 		7B1268062B08247C00400694 /* AssistantConfigurationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistantConfigurationProvider.swift; sourceTree = "<group>"; };
 		7B3DDCC42BAAA722004B5C96 /* AssistantsListDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistantsListDemoView.swift; sourceTree = "<group>"; };
@@ -331,7 +335,9 @@
 				7B436B972AE25045003CE281 /* Utilities */,
 				7BBE7E922AFCC9300096A693 /* Vision */,
 				7BA788CE2AE23A48008825D5 /* ApiKeyIntroView.swift */,
+				0DF957852BB543F100DD2013 /* AIProxyIntroView.swift */,
 				7B436B952AE24A04003CE281 /* OptionsListView.swift */,
+				0DF957832BB53BEF00DD2013 /* ServiceSelectionView.swift */,
 				7BA788D02AE23A49008825D5 /* Assets.xcassets */,
 				7BA788D22AE23A49008825D5 /* SwiftOpenAIExample.entitlements */,
 				7BA788D32AE23A49008825D5 /* Preview Content */,
@@ -557,6 +563,7 @@
 				7BBE7EAB2B02E8FC0096A693 /* ChatMessageDisplayModel.swift in Sources */,
 				7BBE7EA52B02E8A70096A693 /* Sizes.swift in Sources */,
 				7B7239A22AF6260D00646679 /* ChatDisplayMessage.swift in Sources */,
+				0DF957862BB543F100DD2013 /* AIProxyIntroView.swift in Sources */,
 				7B1268052B08246400400694 /* AssistantConfigurationDemoView.swift in Sources */,
 				7B436BB72AE7A2EA003CE281 /* ImagesProvider.swift in Sources */,
 				7B436B962AE24A04003CE281 /* OptionsListView.swift in Sources */,
@@ -571,6 +578,7 @@
 				7B436BB92AE7A2F2003CE281 /* ImagesDemoView.swift in Sources */,
 				7B436BB22AE79370003CE281 /* FilesProvider.swift in Sources */,
 				7BBE7E942AFCC9640096A693 /* ChatVisionProvider.swift in Sources */,
+				0DF957842BB53BEF00DD2013 /* ServiceSelectionView.swift in Sources */,
 				7B436BAD2AE788FB003CE281 /* FineTuningJobDemoView.swift in Sources */,
 				7B436BB02AE79369003CE281 /* FilesDemoView.swift in Sources */,
 				7BBE7E912AFCA52A0096A693 /* ChatVisionDemoView.swift in Sources */,

--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/AIProxyIntroView.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/AIProxyIntroView.swift
@@ -1,0 +1,76 @@
+//
+//  AIProxyIntroView.swift
+//  SwiftOpenAIExample
+//
+//  Created by Lou Zell on 3/27/24.
+//
+
+import SwiftUI
+import SwiftOpenAI
+
+struct AIProxyIntroView: View {
+
+   @State private var partialKey = ""
+   @State private var deviceCheckBypass = ""
+
+   var body: some View {
+      NavigationStack {
+         VStack {
+            Spacer()
+            VStack(spacing: 24) {
+               TextField("Enter partial key", text: $partialKey)
+               TextField("Enter DeviceCheck bypass", text: $deviceCheckBypass)
+            }
+            .padding()
+            .textFieldStyle(.roundedBorder)
+
+            NavigationLink(destination: OptionsListView(openAIService: aiproxyService)) {
+               Text("Continue")
+                  .padding()
+                  .padding(.horizontal, 48)
+                  .foregroundColor(.white)
+                  .background(
+                     Capsule()
+                        .foregroundColor(partialKey.isEmpty ? .gray.opacity(0.2) : Color(red: 64/255, green: 195/255, blue: 125/255)))
+            }
+            .disabled(partialKey.isEmpty)
+            Spacer()
+            Group {
+               Text("You can now use SwiftOpenAI for development and production! AI Proxy keeps your OpenAI API key secure. To configure AI Proxy for your project, or to learn more about how it works, please see the docs at ") + Text("[this link](https://www.aiproxy.pro/docs).")
+            }
+            .font(.caption)
+         }
+         .padding()
+         .navigationTitle("AIProxy Configuration")
+      }
+   }
+
+   private var aiproxyService: some OpenAIService {
+      // Attention AI Proxy customers!
+      //
+      // Please do not let a `deviceCheckBypass` slip into an archived version of your app that you distribute (including through TestFlight).
+      // Doing so would allow an attacker to use the bypass themselves.
+      // The bypass is intended to only be used by developers during development in the iOS simulator (where DeviceCheck does not exist).
+      //
+      // Please retain these conditional checks if you copy this example into your own code.
+      // Your integration code should look like this:
+      //
+      //     #if DEBUG && targetEnvironment(simulator)
+      //           OpenAIServiceFactory.service(
+      //              aiproxyPartialKey: "hardcode-partial-key-here",
+      //              aiproxyDeviceCheckBypass: "hardcode-device-check-bypass-here"
+      //           )
+      //     #else
+      //           OpenAIServiceFactory.service(aiproxyPartialKey: "hardcode-partial-key-here")
+      //     #endif
+      #if DEBUG && targetEnvironment(simulator)
+      OpenAIServiceFactory.service(aiproxyPartialKey: partialKey, aiproxyDeviceCheckBypass: deviceCheckBypass)
+      #else
+      OpenAIServiceFactory.service(aiproxyPartialKey: partialKey)
+      #endif
+   }
+}
+
+#Preview {
+   ApiKeyIntroView()
+}

--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ServiceSelectionView.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ServiceSelectionView.swift
@@ -1,0 +1,47 @@
+//
+//  ServiceSelectionView.swift
+//  SwiftOpenAIExample
+//
+//  Created by Lou Zell on 3/27/24.
+//
+
+import SwiftUI
+
+struct ServiceSelectionView: View {
+
+   var body: some View {
+      NavigationStack {
+         List {
+            Section("Select Service") {
+               NavigationLink(destination: ApiKeyIntroView()) {
+                  VStack(alignment: .leading) {
+                     Text("Default OpenAI Service")
+                        .padding(.bottom, 10)
+                     Group {
+                        Text("Use this service to test SwiftOpenAI functionality by providing your own OpenAI key.")
+                     }
+                     .font(.caption)
+                     .fontWeight(.light)
+                  }
+               }
+
+               NavigationLink(destination: AIProxyIntroView()) {
+                  VStack(alignment: .leading) {
+                     Text("AI Proxy Service")
+                        .padding(.bottom, 10)
+                     Group {
+                        Text("Use this service to test SwiftOpenAI functionality with requests proxied through AI Proxy for key protection.")
+                     }
+                     .font(.caption)
+                     .fontWeight(.light)
+                  }
+               }
+            }
+         }
+      }
+   }
+}
+
+#Preview {
+    ServiceSelectionView()
+}

--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/SwiftOpenAIExampleApp.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/SwiftOpenAIExampleApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct SwiftOpenAIExampleApp: App {
     var body: some Scene {
         WindowGroup {
-           ApiKeyIntroView()
+           ServiceSelectionView()
         }
     }
 }

--- a/Sources/OpenAI/AIProxy/Endpoint+AIProxy.swift
+++ b/Sources/OpenAI/AIProxy/Endpoint+AIProxy.swift
@@ -8,7 +8,9 @@
 import Foundation
 import OSLog
 import DeviceCheck
+#if canImport(UIKit)
 import UIKit
+#endif
 
 private let aiproxyLogger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "UnknownApp",
                                    category: "SwiftOpenAI+AIProxy")
@@ -124,5 +126,9 @@ private func getDeviceCheckToken() async -> String? {
 
 /// Get a unique ID for this user (scoped to the current vendor, and not personally identifiable):
 private func getVendorID() -> String? {
+#if canImport(UIKit)
     return UIDevice.current.identifierForVendor?.uuidString
+#else
+    return nil
+#endif
 }

--- a/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
+++ b/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
@@ -51,4 +51,46 @@ public class OpenAIServiceFactory {
          urlSessionConfiguration: urlSessionConfiguration,
          decoder: decoder)
    }
+
+   /// Creates and returns an instance of `OpenAIService` for use with aiproxy.pro
+   /// Use this service to protect your OpenAI API key before going to production.
+   ///
+   /// Please do not let a `deviceCheckBypass` slip into an archived version of your app that you distribute (including through TestFlight).
+   /// Doing so would allow an attacker to use the bypass themselves.
+   /// The bypass is intended to only be used by developers during development in the iOS simulator (where DeviceCheck does not exist).
+   ///
+   /// Please retain these conditional checks if you copy this example into your own code.
+   /// Your integration code should look like this:
+   ///
+   ///     #if DEBUG && targetEnvironment(simulator)
+   ///         OpenAIServiceFactory.service(
+   ///             aiproxyPartialKey: "hardcode-partial-key-here",
+   ///             aiproxyDeviceCheckBypass: "hardcode-device-check-bypass-here"
+   ///         )
+   ///     #else
+   ///         OpenAIServiceFactory.service(aiproxyPartialKey: "hardcode-partial-key-here")
+   ///     #endif
+   ///
+   /// - Parameters:
+   ///   - aiproxyPartialKey: The partial key provided in the 'API Keys' section of the AI Proxy dashboard.
+   ///                        Please see the integration guide for acquiring your key, at https://www.aiproxy.pro/docs
+   ///   - aiproxyDeviceCheckBypass: The bypass token that is provided in the 'API Keys' section of the AI Proxy dashboard.
+   ///                               Please see the integration guide for acquiring your key, at https://www.aiproxy.pro/docs
+   ///   - configuration: The URL session configuration to be used for network calls (default is `.default`).
+   ///   - decoder: The JSON decoder to be used for parsing API responses (default is `JSONDecoder.init()`).
+   ///
+   /// - Returns: A conformer of OpenAIService that proxies all requests through api.aiproxy.pro
+   public static func service(
+      aiproxyPartialKey: String,
+      aiproxyDeviceCheckBypass: String? = nil,
+      configuration: URLSessionConfiguration = .default,
+      decoder: JSONDecoder = .init())
+   -> some OpenAIService
+   {
+      var service = AIProxyService(partialKey: aiproxyPartialKey)
+      #if DEBUG && targetEnvironment(simulator)
+      service.deviceCheckBypass = aiproxyDeviceCheckBypass
+      #endif
+      return service
+   }
 }


### PR DESCRIPTION
- In the SwiftOpenAI lib, makes AIProxyService accessible through `OpenAIServiceFactory.service(aiproxyPartialKey:aiproxyDeviceCheckBypass:)`

- In the SwiftOpenAIExample sample app, makes `ServiceSelectionView` the first as the first view of the sample app. Users can select 'Default OpenAI Service' or 'AI Proxy Service'. The selection pushes a new view into the stack that collects credentials based on the user's choice.