### PR TITLE
Added AIProxy details to the README

### DIFF
--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/AIProxyIntroView.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/AIProxyIntroView.swift
@@ -36,7 +36,7 @@ struct AIProxyIntroView: View {
             .disabled(partialKey.isEmpty)
             Spacer()
             Group {
-               Text("You can now use SwiftOpenAI for development and production! AI Proxy keeps your OpenAI API key secure. To configure AI Proxy for your project, or to learn more about how it works, please see the docs at ") + Text("[this link](https://www.aiproxy.pro/docs).")
+               Text("You can now use SwiftOpenAI for development and production! AIProxy keeps your OpenAI API key secure. To configure AIProxy for your project, or to learn more about how it works, please see the docs at ") + Text("[this link](https://www.aiproxy.pro/docs).")
             }
             .font(.caption)
          }
@@ -46,7 +46,7 @@ struct AIProxyIntroView: View {
    }
 
    private var aiproxyService: some OpenAIService {
-      // Attention AI Proxy customers!
+      // Attention AIProxy customers!
       //
       // Please do not let a `deviceCheckBypass` slip into an archived version of your app that you distribute (including through TestFlight).
       // Doing so would allow an attacker to use the bypass themselves.

--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ServiceSelectionView.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ServiceSelectionView.swift
@@ -27,10 +27,10 @@ struct ServiceSelectionView: View {
 
                NavigationLink(destination: AIProxyIntroView()) {
                   VStack(alignment: .leading) {
-                     Text("AI Proxy Service")
+                     Text("AIProxy Service")
                         .padding(.bottom, 10)
                      Group {
-                        Text("Use this service to test SwiftOpenAI functionality with requests proxied through AI Proxy for key protection.")
+                        Text("Use this service to test SwiftOpenAI functionality with requests proxied through AIProxy for key protection.")
                      }
                      .font(.caption)
                      .fontWeight(.light)

--- a/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
+++ b/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
@@ -72,9 +72,9 @@ public class OpenAIServiceFactory {
    ///     #endif
    ///
    /// - Parameters:
-   ///   - aiproxyPartialKey: The partial key provided in the 'API Keys' section of the AI Proxy dashboard.
+   ///   - aiproxyPartialKey: The partial key provided in the 'API Keys' section of the AIProxy dashboard.
    ///                        Please see the integration guide for acquiring your key, at https://www.aiproxy.pro/docs
-   ///   - aiproxyDeviceCheckBypass: The bypass token that is provided in the 'API Keys' section of the AI Proxy dashboard.
+   ///   - aiproxyDeviceCheckBypass: The bypass token that is provided in the 'API Keys' section of the AIProxy dashboard.
    ///                               Please see the integration guide for acquiring your key, at https://www.aiproxy.pro/docs
    ///   - configuration: The URL session configuration to be used for network calls (default is `.default`).
    ///   - decoder: The JSON decoder to be used for parsing API responses (default is `JSONDecoder.init()`).


### PR DESCRIPTION
- Added a new section with details about AIProxy, and linked it from the table-of-contents
- Added a blurb about protecting your key to the `getting-an-api-key` section
- Fixed a table-of-contents link to the Azure section
- The code changes are for consistent spelling of "AI Proxy"