### PR TITLE
Added macOS identifier for calls to AIProxy

### DIFF
--- a/Sources/OpenAI/AIProxy/Endpoint+AIProxy.swift
+++ b/Sources/OpenAI/AIProxy/Endpoint+AIProxy.swift
@@ -9,7 +9,10 @@ import Foundation
 import OSLog
 import DeviceCheck
 #if canImport(UIKit)
-import UIKit
+    import UIKit
+#endif
+#if canImport(IOKit)
+    import IOKit
 #endif
 
 private let aiproxyLogger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "UnknownApp",
@@ -51,8 +54,8 @@ extension Endpoint {
       if let betaHeaderField {
          request.addValue(betaHeaderField, forHTTPHeaderField: "OpenAI-Beta")
       }
-      if let vendorID = getVendorID() {
-          request.addValue(vendorID, forHTTPHeaderField: "aiproxy-vendor-id")
+      if let clientID = getClientID() {
+          request.addValue(clientID, forHTTPHeaderField: "aiproxy-client-id")
       }
       if let deviceCheckToken = await getDeviceCheckToken() {
           request.addValue(deviceCheckToken, forHTTPHeaderField: "aiproxy-devicecheck")
@@ -84,8 +87,8 @@ extension Endpoint {
       if let organizationID {
          request.addValue(organizationID, forHTTPHeaderField: "OpenAI-Organization")
       }
-      if let vendorID = getVendorID() {
-          request.addValue(vendorID, forHTTPHeaderField: "aiproxy-vendor-id")
+      if let clientID = getClientID() {
+          request.addValue(clientID, forHTTPHeaderField: "aiproxy-client-id")
       }
       if let deviceCheckToken = await getDeviceCheckToken() {
           request.addValue(deviceCheckToken, forHTTPHeaderField: "aiproxy-devicecheck")
@@ -124,11 +127,90 @@ private func getDeviceCheckToken() async -> String? {
     }
 }
 
-/// Get a unique ID for this user (scoped to the current vendor, and not personally identifiable):
-private func getVendorID() -> String? {
+/// Get a unique ID for this client
+private func getClientID() -> String? {
 #if canImport(UIKit)
     return UIDevice.current.identifierForVendor?.uuidString
+#elseif canImport(IOKit)
+    return getIdentifierFromIOKit()
 #else
     return nil
 #endif
 }
+
+
+// MARK: IOKit conditional dependency
+/// These functions are used on macOS for creating a client identifier.
+/// Unfortunately, macOS does not have a straightforward helper like UIKit's `identifierForVendor`
+#if canImport(IOKit)
+private func getIdentifierFromIOKit() -> String? {
+    guard let macBytes = copy_mac_address() as? Data else {
+        return nil
+    }
+    let macHex = macBytes.map { String(format: "%02X", $0) }
+    return macHex.joined(separator: ":")
+}
+
+// This function is taken from the Apple sample code at:
+// https://developer.apple.com/documentation/appstorereceipts/validating_receipts_on_the_device#3744656
+private func io_service(named name: String, wantBuiltIn: Bool) -> io_service_t? {
+    let default_port = kIOMainPortDefault
+    var iterator = io_iterator_t()
+    defer {
+        if iterator != IO_OBJECT_NULL {
+            IOObjectRelease(iterator)
+        }
+    }
+
+    guard let matchingDict = IOBSDNameMatching(default_port, 0, name),
+        IOServiceGetMatchingServices(default_port,
+                                     matchingDict as CFDictionary,
+                                     &iterator) == KERN_SUCCESS,
+        iterator != IO_OBJECT_NULL
+    else {
+        return nil
+    }
+
+    var candidate = IOIteratorNext(iterator)
+    while candidate != IO_OBJECT_NULL {
+        if let cftype = IORegistryEntryCreateCFProperty(candidate,
+                                                        "IOBuiltin" as CFString,
+                                                        kCFAllocatorDefault,
+                                                        0) {
+            let isBuiltIn = cftype.takeRetainedValue() as! CFBoolean
+            if wantBuiltIn == CFBooleanGetValue(isBuiltIn) {
+                return candidate
+            }
+        }
+
+        IOObjectRelease(candidate)
+        candidate = IOIteratorNext(iterator)
+    }
+
+    return nil
+}
+
+// This function is taken from the Apple sample code at:
+// https://developer.apple.com/documentation/appstorereceipts/validating_receipts_on_the_device#3744656
+private func copy_mac_address() -> CFData? {
+    // Prefer built-in network interfaces.
+    // For example, an external Ethernet adaptor can displace
+    // the built-in Wi-Fi as en0.
+    guard let service = io_service(named: "en0", wantBuiltIn: true)
+            ?? io_service(named: "en1", wantBuiltIn: true)
+            ?? io_service(named: "en0", wantBuiltIn: false)
+        else { return nil }
+    defer { IOObjectRelease(service) }
+
+    if let cftype = IORegistryEntrySearchCFProperty(
+        service,
+        kIOServicePlane,
+        "IOMACAddress" as CFString,
+        kCFAllocatorDefault,
+        IOOptionBits(kIORegistryIterateRecursively | kIORegistryIterateParents)) {
+            return (cftype as! CFData)
+    }
+
+    return nil
+}
+#endif


### PR DESCRIPTION
Requests to AIProxy can be rate limited or rejected based on a client identifier. For example, if an app owner sees that a specific client is abusing their app (violating the terms), they can ban their client from AIProxy's developer dashboard.

This patch puts a client header in place, `aiproxy-client-id`, that is populated on both iOS and macOS.

The iOS client identifier comes from UIKit's `identifierForVendor`. Unfortunately, macOS does not have a comparable convenience method. As a workaround, I have followed Apple's sample code [here](https://developer.apple.com/documentation/appstorereceipts/validating_receipts_on_the_device#3744656)