### PR TITLE
Fix decoding error on assistants response

### DIFF
--- a/Sources/OpenAI/Public/Shared/ResponseFormat.swift
+++ b/Sources/OpenAI/Public/Shared/ResponseFormat.swift
@@ -8,18 +8,44 @@
 import Foundation
 
 
-public struct ResponseFormat: Codable {
-   
-   /// Defaults to text
-   /// Setting to `json_object` enables JSON mode. This guarantees that the message the model generates is valid JSON.
-   /// Note that your system prompt must still instruct the model to produce JSON, and to help ensure you don't forget, the API will throw an error if the string JSON does not appear in your system message.
-   /// Also note that the message content may be partial (i.e. cut off) if `finish_reason="length"`, which indicates the generation exceeded max_tokens or the conversation exceeded the max context length.
-   /// Must be one of `text `or `json_object`.
-   public var type: String?
-   
-   public init(
-      type: String?)
-   {
-      self.type = type
+/// Defaults to text
+/// Setting to `json_object` enables JSON mode. This guarantees that the message the model generates is valid JSON.
+/// Note that your system prompt must still instruct the model to produce JSON, and to help ensure you don't forget, the API will throw an error if the string JSON does not appear in your system message.
+/// Also note that the message content may be partial (i.e. cut off) if `finish_reason="length"`, which indicates the generation exceeded max_tokens or the conversation exceeded the max context length.
+/// Must be one of `text `or `json_object`.
+public enum ResponseFormat: Codable, Equatable {
+   case auto
+   case type(String)
+
+   enum CodingKeys: String, CodingKey {
+      case type = "type"
+   }
+
+   public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      switch self {
+      case .auto:
+         try container.encode("text", forKey: .type)
+      case .type(let responseType):
+         try container.encode(responseType, forKey: .type)
+      }
+   }
+
+   public init(from decoder: Decoder) throws {
+      // Handle the 'type' case:
+      if let container = try? decoder.container(keyedBy: CodingKeys.self),
+         let responseType = try? container.decode(String.self, forKey: .type) {
+         self = .type(responseType)
+         return
+      }
+
+      // Handle the 'auto' case:
+      let container = try decoder.singleValueContainer()
+      switch try container.decode(String.self) {
+      case "auto":
+         self = .auto
+      default:
+         throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid response_format structure")
+      }
    }
 }

--- a/Sources/OpenAI/Public/Shared/ToolChoice.swift
+++ b/Sources/OpenAI/Public/Shared/ToolChoice.swift
@@ -43,18 +43,23 @@ public enum ToolChoice: Codable, Equatable {
    }
    
    public init(from decoder: Decoder) throws {
-       let container = try decoder.container(keyedBy: CodingKeys.self)
-       if let _ = try? container.decode(String.self, forKey: .none) {
-           self = .none
-           return
-       }
-       if let _ = try? container.decode(String.self, forKey: .auto) {
-           self = .auto
-           return
-       }
-       let functionContainer = try container.nestedContainer(keyedBy: FunctionCodingKeys.self, forKey: .function)
-       let name = try functionContainer.decode(String.self, forKey: .name)
-       // Assuming the type is always "function" as default if decoding this case.
-       self = .function(type: "function", name: name)
+      // Handle the 'function' case:
+      if let container = try? decoder.container(keyedBy: CodingKeys.self),
+         let functionContainer = try? container.nestedContainer(keyedBy: FunctionCodingKeys.self, forKey: .function) {
+          let name = try functionContainer.decode(String.self, forKey: .name)
+          self = .function(type: "function", name: name)
+          return
+      }
+
+      // Handle the 'auto' and 'none' cases
+      let container = try decoder.singleValueContainer()
+      switch try container.decode(String.self) {
+          case "none":
+              self = .none
+          case "auto":
+              self = .auto
+      default:
+          throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid tool_choice structure")
+      }
    }
 }

--- a/Tests/OpenAITests/OpenAITests.swift
+++ b/Tests/OpenAITests/OpenAITests.swift
@@ -2,11 +2,117 @@ import XCTest
 @testable import SwiftOpenAI
 
 final class OpenAITests: XCTestCase {
-    func testExample() throws {
-        // XCTest Documentation
-        // https://developer.apple.com/documentation/xctest
 
-        // Defining Test Cases and Test Methods
-        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
-    }
+   // OpenAI is loose with their API contract, unfortunately.
+   // Here we test that `tool_choice` is decodable from a string OR an object,
+   // which is required for deserializing responses from assistants:
+   // https://platform.openai.com/docs/api-reference/runs-v1/createRun#runs-v1-createrun-tool_choice
+   func testToolChoiceIsDecodableFromStringOrObject() throws {
+      let expectedResponseMappings: [(String, ToolChoice)] = [
+         ("\"auto\"", .auto),
+         ("\"none\"", .none),
+         ("{\"type\": \"function\", \"function\": {\"name\": \"my_function\"}}", .function(type: "function", name: "my_function"))
+      ]
+      let decoder = JSONDecoder()
+      for (response, expectedToolChoice) in expectedResponseMappings {
+         print(response)
+         guard let jsonData = response.data(using: .utf8) else {
+            XCTFail("Could not create json from sample response")
+            return
+         }
+         let toolChoice = try decoder.decode(ToolChoice.self, from: jsonData)
+         XCTAssertEqual(toolChoice, expectedToolChoice, "Mapping from \(response) did not yield expected result")
+      }
+   }
+
+   // Here we test that `response_format` is decodable from a string OR an object,
+   // which is required for deserializing responses from assistants:
+   // https://platform.openai.com/docs/api-reference/runs-v1/createRun#runs-v1-createrun-tool_choice
+   func testResponseFormatIsDecodableFromStringOrObject() throws {
+      let expectedResponseMappings: [(String, ResponseFormat)] = [
+         ("\"auto\"", .auto),
+         ("{\"type\": \"json_object\"}", .type("json_object")),
+         ("{\"type\": \"text\"}", .type("text"))
+      ]
+      let decoder = JSONDecoder()
+      for (response, expectedResponseFormat) in expectedResponseMappings {
+         print(response)
+         guard let jsonData = response.data(using: .utf8) else {
+            XCTFail("Could not create json from sample response")
+            return
+         }
+         let responseFormat = try decoder.decode(ResponseFormat.self, from: jsonData)
+         XCTAssertEqual(responseFormat, expectedResponseFormat, "Mapping from \(response) did not yield expected result")
+      }
+   }
+
+   // ResponseFormat is used in other places, and in those places it can *only* be populated with an object.
+   // OpenAI really suffers in API consistency.
+   // If a client sets the ResponseFormat to `auto` (which is now a valid case in the codebase), we
+   // encode to {"type": "text"} to satisfy when response_format can only be an object, such as:
+   // https://platform.openai.com/docs/api-reference/chat/create#chat-create-response_format
+   func testAutoResponseFormatEncodesToText() throws {
+      let jsonData = try JSONEncoder().encode(ResponseFormat.auto)
+      XCTAssertEqual(String(data: jsonData, encoding: .utf8), "{\"type\":\"text\"}")
+   }
+
+   // Verifies that our custom encoding of ResponseFormat supports the 'text' type:
+   func testTextResponseFormatIsEncodable() throws {
+      let jsonData = try JSONEncoder().encode(ResponseFormat.type("text"))
+      XCTAssertEqual(String(data: jsonData, encoding: .utf8), "{\"type\":\"text\"}")
+
+   }
+
+   // Verifies that our custom encoding of ResponseFormat supports the 'json_object' type:
+   func testJSONResponseFormatIsEncodable() throws {
+      let jsonData = try JSONEncoder().encode(ResponseFormat.type("json_object"))
+      XCTAssertEqual(String(data: jsonData, encoding: .utf8), "{\"type\":\"json_object\"}")
+   }
+
+   // Regression test for decoding assistant runs. Thank you to Martin Brian for the repro:
+   // https://gist.github.com/mbrian23/6863ffa705ccbb5097bd07efb2355a30
+   func testThreadRunResponseIsDecodable() throws {
+      let response = """
+        {
+          "id": "run_ZWntP0jJr391lwVu3JqFZbKV",
+          "object": "thread.run",
+          "created_at": 1713979538,
+          "assistant_id": "asst_qxhQxXsecIjqw9cBjFTB6yvd",
+          "thread_id": "thread_CT4hxsN5N0A5vXg4FeR4pOPD",
+          "status": "queued",
+          "started_at": null,
+          "expires_at": 1713980138,
+          "cancelled_at": null,
+          "failed_at": null,
+          "completed_at": null,
+          "required_action": null,
+          "last_error": null,
+          "model": "gpt-4-1106-preview",
+          "instructions": "You answer ever question with ‘hello world’",
+          "tools": [],
+          "file_ids": [],
+          "metadata": {},
+          "temperature": 1.0,
+          "top_p": 1.0,
+          "max_completion_tokens": null,
+          "max_prompt_tokens": null,
+          "truncation_strategy": {
+            "type": "auto",
+            "last_messages": null
+          },
+          "incomplete_details": null,
+          "usage": null,
+          "response_format": "auto",
+          "tool_choice": "auto"
+        }
+        """
+
+      guard let jsonData = response.data(using: .utf8) else {
+         XCTFail("Could not create json from sample response")
+         return
+      }
+      let decoder = JSONDecoder()
+      let runObject = try decoder.decode(RunObject.self, from: jsonData)
+      XCTAssertEqual(runObject.id, "run_ZWntP0jJr391lwVu3JqFZbKV")
+   }
 }

--- a/Tests/OpenAITests/OpenAITests.swift
+++ b/Tests/OpenAITests/OpenAITests.swift
@@ -6,7 +6,7 @@ final class OpenAITests: XCTestCase {
    // OpenAI is loose with their API contract, unfortunately.
    // Here we test that `tool_choice` is decodable from a string OR an object,
    // which is required for deserializing responses from assistants:
-   // https://platform.openai.com/docs/api-reference/runs-v1/createRun#runs-v1-createrun-tool_choice
+   // https://platform.openai.com/docs/api-reference/runs/createRun#runs-createrun-tool_choice
    func testToolChoiceIsDecodableFromStringOrObject() throws {
       let expectedResponseMappings: [(String, ToolChoice)] = [
          ("\"auto\"", .auto),
@@ -27,7 +27,7 @@ final class OpenAITests: XCTestCase {
 
    // Here we test that `response_format` is decodable from a string OR an object,
    // which is required for deserializing responses from assistants:
-   // https://platform.openai.com/docs/api-reference/runs-v1/createRun#runs-v1-createrun-tool_choice
+   // https://platform.openai.com/docs/api-reference/runs/createRun#runs-createrun-response_format
    func testResponseFormatIsDecodableFromStringOrObject() throws {
       let expectedResponseMappings: [(String, ResponseFormat)] = [
          ("\"auto\"", .auto),


### PR DESCRIPTION
The `response_format` and `tool_choice` fields of an assistant's run can either be objects or strings.

Previously, if the `tool_choice` was a string (e.g. 'auto') in the run response, we failed to decode the response. Similarly, if the `responses_type` was a string (e.g. 'auto') in the run response, we failed to decode the response.

This bug was reported by @mbrian23, with a full repro here. Thank you Martin!
https://gist.github.com/mbrian23/6863ffa705ccbb5097bd07efb2355a30

I added regression tests for the failing case.

References:
https://platform.openai.com/docs/api-reference/runs/createRun#runs-createrun-response_format
https://platform.openai.com/docs/api-reference/runs/createRun#runs-createrun-tool_choice
