### PR TITLE
Decoding run stream events

### DIFF
--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/Assistants/AssistantThreadConfigurationProvider.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/Assistants/AssistantThreadConfigurationProvider.swift
@@ -79,6 +79,8 @@ import SwiftOpenAI
                   case nil:
                      print("PROVIDER: tool call nil")
                   }
+            case .threadRunCompleted(let runObject):
+               print("PROVIDER: the run is completed - \(runObject)")
             default: break
             }
          }

--- a/Sources/OpenAI/Public/ResponseModels/Assistants/AssistantStreamEvent.swift
+++ b/Sources/OpenAI/Public/ResponseModels/Assistants/AssistantStreamEvent.swift
@@ -20,35 +20,35 @@ public enum AssistantStreamEvent {
    
    /// Occurs when a run moves to a queued status.
    /// - data is a run
-   case threadRunQueued
+   case threadRunQueued(RunObject)
    
    /// Occurs when a run moves to an in_progress status.
    /// - data is a run
-   case threadRunInProgress
+   case threadRunInProgress(RunObject)
    
    /// Occurs when a run moves to a requires_action status.
    /// - data is a run
-   case threadRunRequiresAction
+   case threadRunRequiresAction(RunObject)
    
    /// Occurs when a run is completed.
    /// - data is a run
-   case threadRunCompleted
+   case threadRunCompleted(RunObject)
    
    /// Occurs when a run fails.
    /// - data is a run
-   case threadRunFailed
+   case threadRunFailed(RunObject)
    
    /// Occurs when a run moves to a cancelling status.
    /// - data is a run
-   case threadRunCancelling
+   case threadRunCancelling(RunObject)
    
    /// Occurs when a run is cancelled.
    /// - data is a run
-   case threadRunCancelled
+   case threadRunCancelled(RunObject)
    
    /// Occurs when a run expires.
    /// - data is a run
-   case threadRunExpired
+   case threadRunExpired(RunObject)
    
    /// Occurs when a run step is created.
    /// - data is a run step

--- a/Sources/OpenAI/Public/ResponseModels/Assistants/AssistantStreamEventObject.swift
+++ b/Sources/OpenAI/Public/ResponseModels/Assistants/AssistantStreamEventObject.swift
@@ -15,6 +15,10 @@ public enum AssistantStreamEventObject: String {
    /// - data is a [thread](https://platform.openai.com/docs/api-reference/threads/object)
    case threadCreated = "thread.created"
    
+   /// Occurs during the life cycle of a run.
+   /// - data is a [run](https://platform.openai.com/docs/api-reference/runs/object)
+   case threadRun = "thread.run"
+   
    /// Occurs when a new run is created.
    /// - data is a [run](https://platform.openai.com/docs/api-reference/runs/object)
    case threadRunCreated =  "thread.run.created"

--- a/Sources/OpenAI/Public/Service/OpenAIService.swift
+++ b/Sources/OpenAI/Public/Service/OpenAIService.swift
@@ -1165,16 +1165,6 @@ extension OpenAIService {
          let task = Task {
             do {
                for try await line in data.lines {
-                  
-                  print("OLIVIA \(line)")
-
-//                  if line.hasPrefix("event:"),
-//                     let data = line.dropFirst(7).data(using: .utf8)
-//                  {
-//                     let json = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? String
-//                     print("sasha \(String(describing: json))")
-//                  }
-                  
                   if line.hasPrefix("data:") && line != "data: [DONE]",
                      let data = line.dropFirst(5).data(using: .utf8) {
                      do {

--- a/Sources/OpenAI/Public/Service/OpenAIService.swift
+++ b/Sources/OpenAI/Public/Service/OpenAIService.swift
@@ -1165,6 +1165,16 @@ extension OpenAIService {
          let task = Task {
             do {
                for try await line in data.lines {
+                  
+                  print("OLIVIA \(line)")
+
+//                  if line.hasPrefix("event:"),
+//                     let data = line.dropFirst(7).data(using: .utf8)
+//                  {
+//                     let json = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? String
+//                     print("sasha \(String(describing: json))")
+//                  }
+                  
                   if line.hasPrefix("data:") && line != "data: [DONE]",
                      let data = line.dropFirst(5).data(using: .utf8) {
                      do {
@@ -1180,6 +1190,35 @@ extension OpenAIService {
                            case .threadRunStepDelta:
                               let decoded = try self.decoder.decode(RunStepDeltaObject.self, from: data)
                               continuation.yield(.threadRunStepDelta(decoded))
+                           case .threadRun:
+                              // We expect a object of type "thread.run.SOME_STATE" in the data object
+                              // However what we get is a `thread.run` object but we can check the status
+                              // of the decoded run to determine the stream event.
+                              // If we check the event line instead, this will contain the expected "event: thread.run.step.completed" for example.
+                              // Therefore the need to stream this event in the following way.
+                              let decoded = try self.decoder.decode(RunObject.self, from: data)
+                              switch RunObject.Status(rawValue: decoded.status) {
+                              case .queued:
+                                 continuation.yield(.threadRunQueued(decoded))
+                              case .inProgress:
+                                 continuation.yield(.threadRunInProgress(decoded))
+                              case .requiresAction:
+                                 continuation.yield(.threadRunRequiresAction(decoded))
+                              case .cancelling:
+                                 continuation.yield(.threadRunCancelling(decoded))
+                              case .cancelled:
+                                 continuation.yield(.threadRunCancelled(decoded))
+                              case .failed:
+                                 continuation.yield(.threadRunFailed(decoded))
+                              case .completed:
+                                 continuation.yield(.threadRunCompleted(decoded))
+                              case .expired:
+                                 continuation.yield(.threadRunExpired(decoded))
+                              default:
+                              #if DEBUG
+                              print("DEBUG threadRun status not found = \(try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any])")
+                              #endif
+                              }
                            default:
                            #if DEBUG
                            print("DEBUG EVENT \(eventObject.rawValue) IGNORED = \(try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any])")
@@ -1187,7 +1226,7 @@ extension OpenAIService {
                            }
                         } else {
                            #if DEBUG
-                           print("DEBUG EVENT DECODE IGNORED= \(try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any])")
+                           print("DEBUG EVENT DECODE IGNORED = \(try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any])")
                            #endif
                         }
                      } catch let DecodingError.keyNotFound(key, context) {


### PR DESCRIPTION
Decoding run stream events

```swift
                             let decoded = try self.decoder.decode(RunObject.self, from: data)
                              switch RunObject.Status(rawValue: decoded.status) {
                              case .queued:
                                 continuation.yield(.threadRunQueued(decoded))
                              case .inProgress:
                                 continuation.yield(.threadRunInProgress(decoded))
                              case .requiresAction:
                                 continuation.yield(.threadRunRequiresAction(decoded))
                              case .cancelling:
                                 continuation.yield(.threadRunCancelling(decoded))
                              case .cancelled:
                                 continuation.yield(.threadRunCancelled(decoded))
                              case .failed:
                                 continuation.yield(.threadRunFailed(decoded))
                              case .completed:
                                 continuation.yield(.threadRunCompleted(decoded))
                              case .expired:
                                 continuation.yield(.threadRunExpired(decoded))
```