### PR TITLE
Make status code available in APIError

### DIFF
--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ChatDemo/ChatProvider.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ChatDemo/ChatProvider.swift
@@ -29,8 +29,10 @@ import SwiftOpenAI
          let logprobs = choices.compactMap(\.logprobs)
          dump(logprobs)
          self.messages = choices.compactMap(\.message.content)
+      } catch APIError.responseUnsuccessful(let description, let statusCode) {
+         self.errorMessage = "Network error with status code: \(statusCode) and description: \(description)"
       } catch {
-         self.errorMessage = "\(error)"
+         self.errorMessage = error.localizedDescription
       }
    }
    
@@ -44,8 +46,10 @@ import SwiftOpenAI
                    let content = result.choices.first?.delta.content ?? ""
                     self.message += content
                 }
+            } catch APIError.responseUnsuccessful(let description, let statusCode) {
+                self.errorMessage = "Network error with status code: \(statusCode) and description: \(description)"
             } catch {
-               self.errorMessage = "\(error)"
+                self.errorMessage = error.localizedDescription
             }
         }
    }

--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ That's all you need to begin accessing the full range of OpenAI endpoints.
 
 ### How to get the status code of network errors
 
-You may want to build UI around the type of error that the API returns. For example, a `429` means that your requests are being rate limited.
-The `APIError` type has a case `responseUnsuccessful` with two associated values: a `description` and `statusCode`. Here is an example of its usage:
+You may want to build UI around the type of error that the API returns.
+For example, a `429` means that your requests are being rate limited.
+The `APIError` type has a case `responseUnsuccessful` with two associated values: a `description` and `statusCode`.
+Here is a usage example using the chat completion API:
 
 ```
       let service = OpenAIServiceFactory.service(apiKey: apiKey)

--- a/README.md
+++ b/README.md
@@ -115,6 +115,27 @@ let service = OpenAIServiceFactory.service(apiKey: apiKey, organizationID: ogani
 
 That's all you need to begin accessing the full range of OpenAI endpoints.
 
+
+### How to get the status code of network errors
+
+You may want to build UI around the type of error that the API returns. For example, a `429` means that your requests are being rate limited.
+The `APIError` type has a case `responseUnsuccessful` with two associated values: a `description` and `statusCode`. Here is an example of its usage:
+
+```
+      let service = OpenAIServiceFactory.service(apiKey: apiKey)
+      let parameters = ChatCompletionParameters(messages: [.init(role: .user, content: .text("hello world"))],
+                                                model: .gpt4o)
+      do {
+         let choices = try await service.startChat(parameters: parameters).choices
+         // Work with choices
+      } catch APIError.responseUnsuccessful(let description, let statusCode) {
+         print("Network error with status code: \(statusCode) and description: \(description)")
+      } catch {
+         print(error.localizedDescription)
+      }
+```
+
+
 ### Audio
 
 ### Audio Transcriptions

--- a/Sources/OpenAI/Public/Service/OpenAIService.swift
+++ b/Sources/OpenAI/Public/Service/OpenAIService.swift
@@ -1087,8 +1087,8 @@ extension OpenAIService {
             // If decoding fails, proceed with a general error message
             errorMessage = "status code \(httpResponse.statusCode)"
          }
-          throw APIError.responseUnsuccessful(description: errorMessage,
-                                              statusCode: httpResponse.statusCode)
+         throw APIError.responseUnsuccessful(description: errorMessage,
+                                             statusCode: httpResponse.statusCode)
       }
       return AsyncThrowingStream { continuation in
          let task = Task {
@@ -1163,8 +1163,8 @@ extension OpenAIService {
             // If decoding fails, proceed with a general error message
             errorMessage = "status code \(httpResponse.statusCode)"
          }
-          throw APIError.responseUnsuccessful(description: errorMessage,
-                                              statusCode: httpResponse.statusCode)
+         throw APIError.responseUnsuccessful(description: errorMessage,
+                                             statusCode: httpResponse.statusCode)
       }
       return AsyncThrowingStream { continuation in
          let task = Task {

--- a/Sources/OpenAI/Public/Service/OpenAIService.swift
+++ b/Sources/OpenAI/Public/Service/OpenAIService.swift
@@ -12,7 +12,7 @@ import Foundation
 public enum APIError: Error {
    
    case requestFailed(description: String)
-   case responseUnsuccessful(description: String)
+   case responseUnsuccessful(description: String, statusCode: Int)
    case invalidData
    case jsonDecodingFailure(description: String)
    case dataCouldNotBeReadMissingData(description: String)
@@ -22,7 +22,7 @@ public enum APIError: Error {
    public var displayDescription: String {
       switch self {
       case .requestFailed(let description): return description
-      case .responseUnsuccessful(let description): return description
+      case .responseUnsuccessful(let description, _): return description
       case .invalidData: return "Invalid data"
       case .jsonDecodingFailure(let description): return description
       case .dataCouldNotBeReadMissingData(let description): return description
@@ -948,7 +948,8 @@ extension OpenAIService {
             // If decoding fails, proceed with a general error message
             errorMessage = "status code \(httpResponse.statusCode)"
          }
-         throw APIError.responseUnsuccessful(description: errorMessage)
+         throw APIError.responseUnsuccessful(description: errorMessage,
+                                             statusCode: httpResponse.statusCode)
       }
       var content: [[String: Any]] = []
       if let jsonString = String(data: data, encoding: .utf8) {
@@ -996,7 +997,8 @@ extension OpenAIService {
                errorMessage += " - No error message provided"
             }
          }
-         throw APIError.responseUnsuccessful(description: errorMessage)
+         throw APIError.responseUnsuccessful(description: errorMessage,
+                                             statusCode: httpResponse.statusCode)
       }
       return data
    }
@@ -1028,7 +1030,8 @@ extension OpenAIService {
             // If decoding fails, proceed with a general error message
             errorMessage = "status code \(httpResponse.statusCode)"
          }
-         throw APIError.responseUnsuccessful(description: errorMessage)
+         throw APIError.responseUnsuccessful(description: errorMessage,
+                                             statusCode: httpResponse.statusCode)
       }
       #if DEBUG
       print("DEBUG JSON FETCH API = \(try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any])")
@@ -1084,7 +1087,8 @@ extension OpenAIService {
             // If decoding fails, proceed with a general error message
             errorMessage = "status code \(httpResponse.statusCode)"
          }
-         throw APIError.responseUnsuccessful(description: errorMessage)
+          throw APIError.responseUnsuccessful(description: errorMessage,
+                                              statusCode: httpResponse.statusCode)
       }
       return AsyncThrowingStream { continuation in
          let task = Task {
@@ -1159,7 +1163,8 @@ extension OpenAIService {
             // If decoding fails, proceed with a general error message
             errorMessage = "status code \(httpResponse.statusCode)"
          }
-         throw APIError.responseUnsuccessful(description: errorMessage)
+          throw APIError.responseUnsuccessful(description: errorMessage,
+                                              statusCode: httpResponse.statusCode)
       }
       return AsyncThrowingStream { continuation in
          let task = Task {


### PR DESCRIPTION
- Developers may want to build custom UI around specific status codes from the API. For example, a rate limit code is `429`, which the end user may receive from either OpenAI or from AIProxy's per-user rate limiting logic. In this case, the developer may want to pop UI notifying the user why the request has failed.

- This patch makes the status code available on the `APIError.responseUnsuccessful` case.

- Added a usage example to the README

