### PR TITLE
Set AIProxy DeviceCheck bypass token as env variable

### DIFF
--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/AIProxyIntroView.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/AIProxyIntroView.swift
@@ -11,7 +11,6 @@ import SwiftOpenAI
 struct AIProxyIntroView: View {
 
    @State private var partialKey = ""
-   @State private var deviceCheckBypass = ""
 
    var body: some View {
       NavigationStack {
@@ -19,10 +18,12 @@ struct AIProxyIntroView: View {
             Spacer()
             VStack(spacing: 24) {
                TextField("Enter partial key", text: $partialKey)
-               TextField("Enter DeviceCheck bypass", text: $deviceCheckBypass)
             }
             .padding()
             .textFieldStyle(.roundedBorder)
+
+            Text("You receive a partial key when you configure an app in the AIProxy dashboard")
+               .font(.caption)
 
             NavigationLink(destination: OptionsListView(openAIService: aiproxyService, options: OptionsListView.APIOption.allCases.filter({ $0 != .localChat }))) {
                Text("Continue")
@@ -46,28 +47,7 @@ struct AIProxyIntroView: View {
    }
 
    private var aiproxyService: some OpenAIService {
-      // Attention AIProxy customers!
-      //
-      // Please do not let a `deviceCheckBypass` slip into an archived version of your app that you distribute (including through TestFlight).
-      // Doing so would allow an attacker to use the bypass themselves.
-      // The bypass is intended to only be used by developers during development in the iOS simulator (where DeviceCheck does not exist).
-      //
-      // Please retain these conditional checks if you copy this example into your own code.
-      // Your integration code should look like this:
-      //
-      //     #if DEBUG && targetEnvironment(simulator)
-      //           OpenAIServiceFactory.service(
-      //              aiproxyPartialKey: "hardcode-partial-key-here",
-      //              aiproxyDeviceCheckBypass: "hardcode-device-check-bypass-here"
-      //           )
-      //     #else
-      //           OpenAIServiceFactory.service(aiproxyPartialKey: "hardcode-partial-key-here")
-      //     #endif
-      #if DEBUG && targetEnvironment(simulator)
-      OpenAIServiceFactory.service(aiproxyPartialKey: partialKey, aiproxyDeviceCheckBypass: deviceCheckBypass)
-      #else
       OpenAIServiceFactory.service(aiproxyPartialKey: partialKey)
-      #endif
    }
 }
 

--- a/README.md
+++ b/README.md
@@ -3012,33 +3012,35 @@ We offer AIProxy support so that developers can build **and** distribute apps us
 
 ### How does my SwiftOpenAI code change?
 
-SwiftOpenAI supports proxying requests through AIProxy with a small change to your integration code.
+SwiftOpenAI supports proxying requests through AIProxy with two changes to your Xcode project:
 
-Instead of initializing `service` with:
+1. Instead of initializing `service` with:
 
         let apiKey = "your_openai_api_key_here"
         let service = OpenAIServiceFactory.service(apiKey: apiKey)
 
 Use:
 
-        #if DEBUG && targetEnvironment(simulator)
         let service = OpenAIServiceFactory.service(
             aiproxyPartialKey: "hardcode_partial_key_here",
-            aiproxyDeviceCheckBypass: "hardcode_device_check_bypass_here"
         )
-        #else
-        let service = OpenAIServiceFactory.service(
-            aiproxyPartialKey: "hardcode_partial_key_here"
-        )
-        #endif
 
-The `aiproxyPartialKey` and `aiproxyDeviceCheckBypass` values are provided to you on the [AIProxy developer dashboard](https://developer.aiproxy.pro).
+The `aiproxyPartialKey` value is provided to you on the [AIProxy developer dashboard](https://developer.aiproxy.pro)
 
-⚠️  It is important that you do not let the `aiproxyDeviceCheckBypass` token leak into a distribution
-build of your app (including TestFlight distributions). Please retain the conditional compilation
-checks that are present in the sample code above.
+2. Add an `AIPROXY_DEVICE_CHECK_BYPASS' env variable to Xcode. This token is provided to you in the AIProxy
+   developer dashboard, and is necessary for the iOS simulator to communicate with the AIProxy backend.
+    - Type `cmd shift ,` to open up the "Edit Schemes" menu in Xcode
+    - Select `Run` in the sidebar
+    - Select `Arguments` from the top nav
+    - Add to the "Environment Variables" section (not the "Arguments Passed on Launch" section) an env
+      variable with name `AIPROXY_DEVICE_CHECK_BYPASS` and value that we provided you in the AIProxy dashboard
 
-#### What is the `aiproxyDeviceCheckBypass` constant?
+
+⚠️  The `AIPROXY_DEVICE_CHECK_BYPASS` is intended for the simulator only. Do not let it leak into
+a distribution build of your app (including a TestFlight distribution). If you follow the steps above,
+then the constant won't leak because env variables are not packaged into the app bundle.
+
+#### What is the `AIPROXY_DEVICE_CHECK_BYPASS` constant?
 
 AIProxy uses Apple's [DeviceCheck](https://developer.apple.com/documentation/devicecheck) to ensure
 that requests received by the backend originated from your app on a legitimate Apple device.

--- a/Sources/OpenAI/AIProxy/AIProxyService.swift
+++ b/Sources/OpenAI/AIProxy/AIProxyService.swift
@@ -11,7 +11,6 @@ struct AIProxyService: OpenAIService {
 
    let session: URLSession
    let decoder: JSONDecoder
-   var deviceCheckBypass: String?
 
    private let sessionID = UUID().uuidString
 
@@ -45,7 +44,7 @@ struct AIProxyService: OpenAIService {
       parameters: AudioTranscriptionParameters)
       async throws -> AudioObject
    {
-       let request = try await OpenAIAPI.audio(.transcriptions).multiPartRequest(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post,  params: parameters, deviceCheckBypass: deviceCheckBypass)
+       let request = try await OpenAIAPI.audio(.transcriptions).multiPartRequest(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post,  params: parameters)
       return try await fetch(type: AudioObject.self, with: request)
    }
 
@@ -53,7 +52,7 @@ struct AIProxyService: OpenAIService {
       parameters: AudioTranslationParameters)
       async throws -> AudioObject
    {
-      let request = try await OpenAIAPI.audio(.translations).multiPartRequest(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.audio(.translations).multiPartRequest(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(type: AudioObject.self, with: request)
    }
 
@@ -61,7 +60,7 @@ struct AIProxyService: OpenAIService {
       parameters: AudioSpeechParameters)
       async throws -> AudioSpeechObject
    {
-      let request = try await OpenAIAPI.audio(.speech).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.audio(.speech).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       let data = try await fetchAudio(with: request)
       return AudioSpeechObject(output: data)
    }
@@ -74,7 +73,7 @@ struct AIProxyService: OpenAIService {
    {
       var chatParameters = parameters
       chatParameters.stream = false
-      let request = try await OpenAIAPI.chat.request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: chatParameters, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.chat.request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: chatParameters)
       return try await fetch(type: ChatCompletionObject.self, with: request)
    }
 
@@ -85,7 +84,7 @@ struct AIProxyService: OpenAIService {
       var chatParameters = parameters
       chatParameters.stream = true
       chatParameters.streamOptions = .init(includeUsage: true)
-      let request = try await OpenAIAPI.chat.request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: chatParameters, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.chat.request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: chatParameters)
       return try await fetchStream(type: ChatCompletionChunkObject.self, with: request)
    }
 
@@ -95,7 +94,7 @@ struct AIProxyService: OpenAIService {
       parameters: EmbeddingParameter)
       async throws -> OpenAIResponse<EmbeddingObject>
    {
-      let request = try await OpenAIAPI.embeddings.request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.embeddings.request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(type: OpenAIResponse<EmbeddingObject>.self, with: request)
    }
 
@@ -105,7 +104,7 @@ struct AIProxyService: OpenAIService {
       parameters: FineTuningJobParameters)
       async throws -> FineTuningJobObject
    {
-      let request = try await OpenAIAPI.fineTuning(.create).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.fineTuning(.create).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(type: FineTuningJobObject.self, with: request)
    }
 
@@ -123,7 +122,7 @@ struct AIProxyService: OpenAIService {
          queryItems = [.init(name: "limit", value: "\(limit)")]
       }
 
-      let request = try await OpenAIAPI.fineTuning(.list).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.fineTuning(.list).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems)
       return try await fetch(type: OpenAIResponse<FineTuningJobObject>.self, with: request)
    }
 
@@ -131,7 +130,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> FineTuningJobObject
    {
-      let request = try await OpenAIAPI.fineTuning(.retrieve(jobID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.fineTuning(.retrieve(jobID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get)
       return try await fetch(type: FineTuningJobObject.self, with: request)
    }
 
@@ -139,7 +138,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> FineTuningJobObject
    {
-      let request = try await OpenAIAPI.fineTuning(.cancel(jobID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.fineTuning(.cancel(jobID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post)
       return try await fetch(type: FineTuningJobObject.self, with: request)
    }
 
@@ -157,7 +156,7 @@ struct AIProxyService: OpenAIService {
       } else if let limit {
          queryItems = [.init(name: "limit", value: "\(limit)")]
       }
-      let request = try await OpenAIAPI.fineTuning(.events(jobID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.fineTuning(.events(jobID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems)
       return try await fetch(type: OpenAIResponse<FineTuningJobEventObject>.self, with: request)
    }
 
@@ -166,7 +165,7 @@ struct AIProxyService: OpenAIService {
    func listFiles()
       async throws -> OpenAIResponse<FileObject>
    {
-      let request = try await OpenAIAPI.file(.list).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.file(.list).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get)
       return try await fetch(type: OpenAIResponse<FileObject>.self, with: request)
    }
 
@@ -174,7 +173,7 @@ struct AIProxyService: OpenAIService {
       parameters: FileParameters)
       async throws -> FileObject
    {
-      let request = try await OpenAIAPI.file(.upload).multiPartRequest(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.file(.upload).multiPartRequest(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(type: FileObject.self, with: request)
    }
 
@@ -182,7 +181,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> DeletionStatus
    {
-      let request = try await OpenAIAPI.file(.delete(fileID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .delete, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.file(.delete(fileID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .delete)
       return try await fetch(type: DeletionStatus.self, with: request)
    }
 
@@ -190,7 +189,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> FileObject
    {
-      let request = try await OpenAIAPI.file(.retrieve(fileID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.file(.retrieve(fileID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get)
       return try await fetch(type: FileObject.self, with: request)
    }
 
@@ -198,7 +197,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> [[String: Any]]
    {
-      let request = try await OpenAIAPI.file(.retrieveFileContent(fileID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.file(.retrieveFileContent(fileID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get)
       return try await fetchContentsOfFile(request: request)
    }
 
@@ -208,7 +207,7 @@ struct AIProxyService: OpenAIService {
       parameters: ImageCreateParameters)
       async throws -> OpenAIResponse<ImageObject>
    {
-      let request = try await OpenAIAPI.images(.generations).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.images(.generations).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(type: OpenAIResponse<ImageObject>.self,  with: request)
    }
 
@@ -216,7 +215,7 @@ struct AIProxyService: OpenAIService {
       parameters: ImageEditParameters)
       async throws -> OpenAIResponse<ImageObject>
    {
-      let request = try await OpenAIAPI.images(.edits).multiPartRequest(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.images(.edits).multiPartRequest(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(type: OpenAIResponse<ImageObject>.self, with: request)
    }
 
@@ -224,7 +223,7 @@ struct AIProxyService: OpenAIService {
       parameters: ImageVariationParameters)
       async throws -> OpenAIResponse<ImageObject>
    {
-      let request = try await OpenAIAPI.images(.variations).multiPartRequest(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.images(.variations).multiPartRequest(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(type: OpenAIResponse<ImageObject>.self, with: request)
    }
 
@@ -233,7 +232,7 @@ struct AIProxyService: OpenAIService {
    func listModels()
       async throws -> OpenAIResponse<ModelObject>
    {
-      let request = try await OpenAIAPI.model(.list).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.model(.list).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get)
       return try await fetch(type: OpenAIResponse<ModelObject>.self,  with: request)
    }
 
@@ -241,7 +240,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> ModelObject
    {
-      let request = try await OpenAIAPI.model(.retrieve(modelID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.model(.retrieve(modelID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get)
       return try await fetch(type: ModelObject.self,  with: request)
    }
 
@@ -249,7 +248,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> DeletionStatus
    {
-      let request = try await OpenAIAPI.model(.deleteFineTuneModel(modelID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .delete, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.model(.deleteFineTuneModel(modelID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .delete)
       return try await fetch(type: DeletionStatus.self,  with: request)
    }
 
@@ -259,7 +258,7 @@ struct AIProxyService: OpenAIService {
       parameters: ModerationParameter<String>)
       async throws -> ModerationObject
    {
-      let request = try await OpenAIAPI.moderations.request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.moderations.request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(type: ModerationObject.self, with: request)
    }
 
@@ -267,7 +266,7 @@ struct AIProxyService: OpenAIService {
       parameters: ModerationParameter<[String]>)
       async throws -> ModerationObject
    {
-      let request = try await OpenAIAPI.moderations.request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.moderations.request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(type: ModerationObject.self, with: request)
    }
 
@@ -277,7 +276,7 @@ struct AIProxyService: OpenAIService {
       parameters: AssistantParameters)
       async throws -> AssistantObject
    {
-      let request = try await OpenAIAPI.assistant(.create).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.assistant(.create).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: AssistantObject.self, with: request)
    }
 
@@ -285,7 +284,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> AssistantObject
    {
-      let request = try await OpenAIAPI.assistant(.retrieve(assistantID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.assistant(.retrieve(assistantID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: AssistantObject.self, with: request)
    }
 
@@ -294,7 +293,7 @@ struct AIProxyService: OpenAIService {
       parameters: AssistantParameters)
       async throws -> AssistantObject
    {
-      let request = try await OpenAIAPI.assistant(.modify(assistantID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.assistant(.modify(assistantID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: AssistantObject.self, with: request)
    }
 
@@ -302,7 +301,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> DeletionStatus
    {
-      let request = try await OpenAIAPI.assistant(.delete(assistantID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.assistant(.delete(assistantID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: DeletionStatus.self, with: request)
    }
 
@@ -326,7 +325,7 @@ struct AIProxyService: OpenAIService {
       if let before {
          queryItems.append(.init(name: "before", value: before))
       }
-      let request = try await OpenAIAPI.assistant(.list).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.assistant(.list).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: OpenAIResponse<AssistantObject>.self, with: request)
    }
 
@@ -336,14 +335,14 @@ struct AIProxyService: OpenAIService {
       parameters: CreateThreadParameters)
       async throws -> ThreadObject
    {
-      let request = try await OpenAIAPI.thread(.create).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.thread(.create).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: ThreadObject.self, with: request)
    }
 
    func retrieveThread(id: String)
       async throws -> ThreadObject
    {
-      let request = try await OpenAIAPI.thread(.retrieve(threadID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.thread(.retrieve(threadID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: ThreadObject.self, with: request)
    }
 
@@ -352,7 +351,7 @@ struct AIProxyService: OpenAIService {
       parameters: ModifyThreadParameters)
       async throws -> ThreadObject
    {
-      let request = try await OpenAIAPI.thread(.modify(threadID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.thread(.modify(threadID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: ThreadObject.self, with: request)
    }
 
@@ -360,7 +359,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> DeletionStatus
    {
-      let request = try await OpenAIAPI.thread(.delete(threadID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.thread(.delete(threadID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: DeletionStatus.self, with: request)
    }
 
@@ -371,7 +370,7 @@ struct AIProxyService: OpenAIService {
       parameters: MessageParameter)
       async throws -> MessageObject
    {
-      let request = try await OpenAIAPI.message(.create(threadID: threadID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.message(.create(threadID: threadID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: MessageObject.self, with: request)
    }
 
@@ -380,7 +379,7 @@ struct AIProxyService: OpenAIService {
       messageID: String)
       async throws -> MessageObject
    {
-      let request = try await OpenAIAPI.message(.retrieve(threadID: threadID, messageID: messageID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.message(.retrieve(threadID: threadID, messageID: messageID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: MessageObject.self, with: request)
    }
 
@@ -390,7 +389,7 @@ struct AIProxyService: OpenAIService {
       parameters: ModifyMessageParameters)
       async throws -> MessageObject
    {
-      let request = try await OpenAIAPI.message(.modify(threadID: threadID, messageID: messageID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.message(.modify(threadID: threadID, messageID: messageID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: MessageObject.self, with: request)
    }
 
@@ -416,7 +415,7 @@ struct AIProxyService: OpenAIService {
       if let before {
          queryItems.append(.init(name: "before", value: before))
       }
-      let request = try await OpenAIAPI.message(.list(threadID: threadID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.message(.list(threadID: threadID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: OpenAIResponse<MessageObject>.self, with: request)
    }
 
@@ -427,7 +426,7 @@ struct AIProxyService: OpenAIService {
       parameters: RunParameter)
       async throws -> RunObject
    {
-      let request = try await OpenAIAPI.run(.create(threadID: threadID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.run(.create(threadID: threadID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: RunObject.self, with: request)
    }
 
@@ -436,7 +435,7 @@ struct AIProxyService: OpenAIService {
       runID: String)
       async throws -> RunObject
    {
-      let request = try await OpenAIAPI.run(.retrieve(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.run(.retrieve(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: RunObject.self, with: request)
    }
 
@@ -446,7 +445,7 @@ struct AIProxyService: OpenAIService {
       parameters: ModifyRunParameters)
       async throws -> RunObject
    {
-      let request = try await OpenAIAPI.run(.modify(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.run(.modify(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: RunObject.self, with: request)
    }
 
@@ -471,7 +470,7 @@ struct AIProxyService: OpenAIService {
       if let before {
          queryItems.append(.init(name: "before", value: before))
       }
-      let request = try await OpenAIAPI.run(.list(threadID: threadID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.run(.list(threadID: threadID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: OpenAIResponse<RunObject>.self, with: request)
    }
 
@@ -480,7 +479,7 @@ struct AIProxyService: OpenAIService {
       runID: String)
       async throws -> RunObject
    {
-      let request = try await OpenAIAPI.run(.cancel(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.run(.cancel(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: RunObject.self, with: request)
    }
 
@@ -490,7 +489,7 @@ struct AIProxyService: OpenAIService {
       parameters: RunToolsOutputParameter)
       async throws -> RunObject
    {
-      let request = try await OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: RunObject.self, with: request)
    }
 
@@ -498,7 +497,7 @@ struct AIProxyService: OpenAIService {
       parameters: CreateThreadAndRunParameter)
       async throws -> RunObject
    {
-      let request = try await OpenAIAPI.run(.createThreadAndRun).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.run(.createThreadAndRun).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(type: RunObject.self, with: request)
    }
 
@@ -510,7 +509,7 @@ struct AIProxyService: OpenAIService {
       stepID: String)
       async throws -> RunStepObject
    {
-      let request = try await OpenAIAPI.runStep(.retrieve(threadID: threadID, runID: runID, stepID: stepID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.runStep(.retrieve(threadID: threadID, runID: runID, stepID: stepID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: RunStepObject.self, with: request)
    }
 
@@ -536,7 +535,7 @@ struct AIProxyService: OpenAIService {
       if let before {
          queryItems.append(.init(name: "before", value: before))
       }
-      let request = try await OpenAIAPI.runStep(.list(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.runStep(.list(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: OpenAIResponse<RunStepObject>.self, with: request)
    }
 
@@ -547,7 +546,7 @@ struct AIProxyService: OpenAIService {
    {
       var runParameters = parameters
       runParameters.stream = true
-      let request = try await OpenAIAPI.run(.create(threadID: threadID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: runParameters, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.run(.create(threadID: threadID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: runParameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetchAssistantStreamEvents(with: request)
    }
 
@@ -556,7 +555,7 @@ struct AIProxyService: OpenAIService {
       async throws -> AsyncThrowingStream<AssistantStreamEvent, Error> {
       var runParameters = parameters
       runParameters.stream = true
-      let request = try await OpenAIAPI.run(.createThreadAndRun).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.run(.createThreadAndRun).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetchAssistantStreamEvents(with: request)
    }
 
@@ -568,7 +567,7 @@ struct AIProxyService: OpenAIService {
    {
       var runToolsOutputParameter = parameters
       runToolsOutputParameter.stream = true
-      let request = try await OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetchAssistantStreamEvents(with: request)
    }
 
@@ -578,7 +577,7 @@ struct AIProxyService: OpenAIService {
       parameters: BatchParameter)
       async throws -> BatchObject
    {
-      let request = try await OpenAIAPI.batch(.create).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.batch(.create).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(type: BatchObject.self, with: request)
    }
 
@@ -586,7 +585,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> BatchObject
    {
-      let request = try await OpenAIAPI.batch(.retrieve(batchID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.batch(.retrieve(batchID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get)
       return try await fetch(type: BatchObject.self, with: request)
    }
 
@@ -594,7 +593,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> BatchObject
    {
-      let request = try await OpenAIAPI.batch(.cancel(batchID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.batch(.cancel(batchID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post)
       return try await fetch(type: BatchObject.self, with: request)
    }
 
@@ -610,7 +609,7 @@ struct AIProxyService: OpenAIService {
       if let after {
          queryItems.append(.init(name: "after", value: after))
       }
-      let request = try await OpenAIAPI.batch(.list).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.batch(.list).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems)
       return try await fetch(type: OpenAIResponse<BatchObject>.self, with: request)
    }
 
@@ -620,7 +619,7 @@ struct AIProxyService: OpenAIService {
       parameters: VectorStoreParameter)
       async throws -> VectorStoreObject
    {
-      let request = try await OpenAIAPI.vectorStore(.create).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.vectorStore(.create).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: VectorStoreObject.self, with: request)
    }
 
@@ -644,7 +643,7 @@ struct AIProxyService: OpenAIService {
       if let before {
          queryItems.append(.init(name: "before", value: before))
       }
-      let request = try await OpenAIAPI.vectorStore(.list).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.vectorStore(.list).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: OpenAIResponse<VectorStoreObject>.self, with: request)
    }
 
@@ -652,7 +651,7 @@ struct AIProxyService: OpenAIService {
       id: String) async throws
       -> VectorStoreObject
    {
-      let request = try await OpenAIAPI.vectorStore(.retrieve(vectorStoreID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.vectorStore(.retrieve(vectorStoreID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: VectorStoreObject.self, with: request)
    }
 
@@ -661,7 +660,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> VectorStoreObject
    {
-      let request = try await OpenAIAPI.vectorStore(.modify(vectorStoreID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.vectorStore(.modify(vectorStoreID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: VectorStoreObject.self, with: request)
    }
 
@@ -669,7 +668,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> DeletionStatus
    {
-      let request = try await OpenAIAPI.vectorStore(.modify(vectorStoreID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.vectorStore(.modify(vectorStoreID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: DeletionStatus.self, with: request)
    }
 
@@ -680,7 +679,7 @@ struct AIProxyService: OpenAIService {
       parameters: VectorStoreFileParameter)
       async throws -> VectorStoreFileObject
    {
-      let request = try await OpenAIAPI.vectorStore(.create).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.vectorStore(.create).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: VectorStoreFileObject.self, with: request)
    }
 
@@ -709,7 +708,7 @@ struct AIProxyService: OpenAIService {
       if let filter {
          queryItems.append(.init(name: "filter", value: filter))
       }
-      let request = try await OpenAIAPI.vectorStoreFile(.list(vectorStoreID: vectorStoreID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.vectorStoreFile(.list(vectorStoreID: vectorStoreID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: OpenAIResponse<VectorStoreFileObject>.self, with: request)
    }
 
@@ -718,7 +717,7 @@ struct AIProxyService: OpenAIService {
       fileID: String)
       async throws -> VectorStoreFileObject
    {
-      let request = try await OpenAIAPI.vectorStoreFile(.retrieve(vectorStoreID: vectorStoreID, fileID: fileID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.vectorStoreFile(.retrieve(vectorStoreID: vectorStoreID, fileID: fileID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: VectorStoreFileObject.self, with: request)
    }
 
@@ -727,7 +726,7 @@ struct AIProxyService: OpenAIService {
       fileID: String)
       async throws -> DeletionStatus
    {
-      let request = try await OpenAIAPI.vectorStoreFile(.delete(vectorStoreID: vectorStoreID, fileID: fileID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2, deviceCheckBypass: deviceCheckBypass)
+      let request = try await OpenAIAPI.vectorStoreFile(.delete(vectorStoreID: vectorStoreID, fileID: fileID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(type: DeletionStatus.self, with: request)
    }
 

--- a/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
+++ b/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
@@ -61,50 +61,23 @@ public class OpenAIServiceFactory {
    /// Creates and returns an instance of `OpenAIService` for use with aiproxy.pro
    /// Use this service to protect your OpenAI API key before going to production.
    ///
-   /// Please do not let a `deviceCheckBypass` slip into an archived version of your app that you distribute (including through TestFlight).
-   /// Doing so would allow an attacker to use the bypass themselves.
-   /// The bypass is intended to only be used by developers during development in the iOS simulator (where DeviceCheck does not exist).
-   ///
-   /// Please retain these conditional checks if you copy this example into your own code.
-   /// Your integration code should look like this:
-   ///
-   ///     #if DEBUG && targetEnvironment(simulator)
-   ///         OpenAIServiceFactory.service(
-   ///             aiproxyPartialKey: "hardcode-partial-key-here",
-   ///             aiproxyDeviceCheckBypass: "hardcode-device-check-bypass-here"
-   ///         )
-   ///     #else
-   ///         OpenAIServiceFactory.service(aiproxyPartialKey: "hardcode-partial-key-here")
-   ///     #endif
-   ///
    /// - Parameters:
    ///   - aiproxyPartialKey: The partial key provided in the 'API Keys' section of the AIProxy dashboard.
    ///                        Please see the integration guide for acquiring your key, at https://www.aiproxy.pro/docs
    ///   - aiproxyClientID: If your app already has client or user IDs that you want to annotate AIProxy requests
    ///                      with, you can pass a clientID here. If you do not have existing client or user IDs, leave
    ///                      the `clientID` argument out, and IDs will be generated automatically for you.
-   ///   - aiproxyDeviceCheckBypass: The bypass token that is provided in the 'API Keys' section of the AIProxy dashboard.
-   ///                               Please see the integration guide for acquiring your key, at https://www.aiproxy.pro/docs
-   ///   - configuration: The URL session configuration to be used for network calls (default is `.default`).
-   ///   - decoder: The JSON decoder to be used for parsing API responses (default is `JSONDecoder.init()`).
    ///
    /// - Returns: A conformer of OpenAIService that proxies all requests through api.aiproxy.pro
    public static func service(
       aiproxyPartialKey: String,
-      aiproxyClientID: String? = nil,
-      aiproxyDeviceCheckBypass: String? = nil,
-      configuration: URLSessionConfiguration = .default,
-      decoder: JSONDecoder = .init())
+      aiproxyClientID: String? = nil)
    -> some OpenAIService
    {
-      var service = AIProxyService(
+      AIProxyService(
         partialKey: aiproxyPartialKey,
         clientID: aiproxyClientID
       )
-      #if DEBUG && targetEnvironment(simulator)
-      service.deviceCheckBypass = aiproxyDeviceCheckBypass
-      #endif
-      return service
    }
    
    // MARK: Ollama


### PR DESCRIPTION
- The DeviceCheck bypass token is used for AIProxy customers to make requests to AIProxy from the iOS simulator, where DeviceCheck is not available.
- If the token leaks into a production build of the app, then attackers can use the bypass token themselves to skip one layer of security that AIProxy provides.
- This patch adjusts the way that developers set the bypass token, removing it from the source code and adding it instead as an env variable. Env variables are not packaged up in distribution app bundles, and are therefore harder to make leak into a production release of your app.
- Updated the README with new instructions for adding the `AIPROXY_DEVICE_CHECK_BYPASS` env variable