### PR TITLE
Fixed SubmitToolsOutput Function

### DIFF
--- a/Sources/OpenAI/AIProxy/AIProxyService.swift
+++ b/Sources/OpenAI/AIProxy/AIProxyService.swift
@@ -572,7 +572,7 @@ struct AIProxyService: OpenAIService {
    {
       var runToolsOutputParameter = parameters
       runToolsOutputParameter.stream = true
-      let request = try await OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: runToolsOutputParameter, betaHeaderField: Self.assistantsBetaV2)
       return try await fetchAssistantStreamEvents(with: request)
    }
 

--- a/Sources/OpenAI/Azure/DefaultOpenAIAzureService.swift
+++ b/Sources/OpenAI/Azure/DefaultOpenAIAzureService.swift
@@ -504,7 +504,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
          apiKey: apiKey,
          organizationID: nil,
          method: .post,
-         params: parameters,
+         params: runToolsOutputParameter,
          queryItems: initialQueryItems,
          betaHeaderField: Self.assistantsBetaV2,
          extraHeaders: extraHeaders)

--- a/Sources/OpenAI/Public/Service/DefaultOpenAIService.swift
+++ b/Sources/OpenAI/Public/Service/DefaultOpenAIService.swift
@@ -566,7 +566,7 @@ struct DefaultOpenAIService: OpenAIService {
    {
       var runToolsOutputParameter = parameters
       runToolsOutputParameter.stream = true
-      let request = try OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: runToolsOutputParameter, betaHeaderField: Self.assistantsBetaV2)
       return try await fetchAssistantStreamEvents(with: request)
    }
    


### PR DESCRIPTION
The submitOutput function was sending wrong parameters where stream was false , because of this the response was an empty stream object. Just fixed it by passing runToolsOutputParameter.