### PR TITLE
Add serviceURL to AIProxy integration

### DIFF
--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/AIProxyIntroView.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/AIProxyIntroView.swift
@@ -11,6 +11,7 @@ import SwiftOpenAI
 struct AIProxyIntroView: View {
 
    @State private var partialKey = ""
+   @State private var serviceURL = ""
 
    var body: some View {
       NavigationStack {
@@ -18,11 +19,12 @@ struct AIProxyIntroView: View {
             Spacer()
             VStack(spacing: 24) {
                TextField("Enter partial key", text: $partialKey)
+               TextField("Enter your service's URL", text: $serviceURL)
             }
             .padding()
             .textFieldStyle(.roundedBorder)
 
-            Text("You receive a partial key when you configure an app in the AIProxy dashboard")
+            Text("You receive a partial key and service URL when you configure an app in the AIProxy dashboard")
                .font(.caption)
 
             NavigationLink(destination: OptionsListView(openAIService: aiproxyService, options: OptionsListView.APIOption.allCases.filter({ $0 != .localChat }))) {
@@ -47,7 +49,10 @@ struct AIProxyIntroView: View {
    }
 
    private var aiproxyService: some OpenAIService {
-      OpenAIServiceFactory.service(aiproxyPartialKey: partialKey)
+      OpenAIServiceFactory.service(
+         aiproxyPartialKey: partialKey,
+         aiproxyServiceURL: serviceURL != "" ? serviceURL : nil
+      )
    }
 }
 

--- a/README.md
+++ b/README.md
@@ -88,8 +88,14 @@ To configure AIProxy, see the instructions [here](#aiproxy).
 1. Open your Swift project in Xcode.
 2. Go to `File` ->  `Add Package Dependency`.
 3. In the search bar, enter [this URL](https://github.com/jamesrochabrun/SwiftOpenAI).
-4. Choose the version you'd like to install.
+4. Choose the version you'd like to install (see the note below).
 5. Click `Add Package`.
+
+Note: Xcode has a quirk where it defaults an SPM package's upper limit to 2.0.0. This package is beyond that
+limit, so you should not accept the defaults that Xcode proposes. Instead, enter the lower bound of the
+[release version](https://github.com/jamesrochabrun/SwiftOpenAI/releases) that you'd like to support, and then
+tab out of the input box for Xcode to adjust the upper bound. Alternatively, you may select `branch` -> `main`
+to stay on the bleeding edge.
 
 ## Usage
 
@@ -3022,10 +3028,11 @@ SwiftOpenAI supports proxying requests through AIProxy with two changes to your 
 Use:
 
         let service = OpenAIServiceFactory.service(
-            aiproxyPartialKey: "hardcode_partial_key_here",
+            aiproxyPartialKey: "your_partial_key_goes_here",
+            aiproxyServiceURL: "your_service_url_goes_here"
         )
 
-The `aiproxyPartialKey` value is provided to you on the [AIProxy developer dashboard](https://developer.aiproxy.pro)
+The `aiproxyPartialKey` and `aiproxyServiceURL` values are provided to you on the [AIProxy developer dashboard](https://developer.aiproxy.pro)
 
 2. Add an `AIPROXY_DEVICE_CHECK_BYPASS' env variable to Xcode. This token is provided to you in the AIProxy
    developer dashboard, and is necessary for the iOS simulator to communicate with the AIProxy backend.

--- a/Sources/OpenAI/AIProxy/AIProxyService.swift
+++ b/Sources/OpenAI/AIProxy/AIProxyService.swift
@@ -20,6 +20,11 @@ struct AIProxyService: OpenAIService {
    /// Your partial key is provided during the integration process at dashboard.aiproxy.pro
    /// Please see the [integration guide](https://www.aiproxy.pro/docs/integration-guide.html) for acquiring your partial key
    private let partialKey: String
+   /// Your service URL is also provided during the integration process. If you integrated before
+   /// July 22nd, 2024, you can continue to leave this blank.
+   private let serviceURL: String?
+   /// Optionally supply your own client IDs to annotate requests with in the AIProxy developer dashboard.
+   /// It is safe to leave this blank (most people do). If you leave it blank, AIProxy generates client IDs for you.
    private let clientID: String?
    /// Set this flag to TRUE if you need to print request events in DEBUG builds.
    private let debugEnabled: Bool
@@ -31,6 +36,7 @@ struct AIProxyService: OpenAIService {
 
    init(
       partialKey: String,
+      serviceURL: String? = nil,
       clientID: String? = nil,
       organizationID: String? = nil,
       debugEnabled: Bool)
@@ -42,6 +48,7 @@ struct AIProxyService: OpenAIService {
       )
       self.decoder = JSONDecoder()
       self.partialKey = partialKey
+      self.serviceURL = serviceURL
       self.clientID = clientID
       self.organizationID = organizationID
       self.debugEnabled = debugEnabled
@@ -53,7 +60,7 @@ struct AIProxyService: OpenAIService {
       parameters: AudioTranscriptionParameters)
       async throws -> AudioObject
    {
-       let request = try await OpenAIAPI.audio(.transcriptions).multiPartRequest(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post,  params: parameters)
+      let request = try await OpenAIAPI.audio(.transcriptions).multiPartRequest(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post,  params: parameters)
       return try await fetch(debugEnabled: debugEnabled, type: AudioObject.self, with: request)
    }
 
@@ -61,7 +68,7 @@ struct AIProxyService: OpenAIService {
       parameters: AudioTranslationParameters)
       async throws -> AudioObject
    {
-      let request = try await OpenAIAPI.audio(.translations).multiPartRequest(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
+      let request = try await OpenAIAPI.audio(.translations).multiPartRequest(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(debugEnabled: debugEnabled, type: AudioObject.self, with: request)
    }
 
@@ -69,7 +76,7 @@ struct AIProxyService: OpenAIService {
       parameters: AudioSpeechParameters)
       async throws -> AudioSpeechObject
    {
-      let request = try await OpenAIAPI.audio(.speech).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
+      let request = try await OpenAIAPI.audio(.speech).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       let data = try await fetchAudio(with: request)
       return AudioSpeechObject(output: data)
    }
@@ -82,7 +89,7 @@ struct AIProxyService: OpenAIService {
    {
       var chatParameters = parameters
       chatParameters.stream = false
-      let request = try await OpenAIAPI.chat.request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: chatParameters)
+      let request = try await OpenAIAPI.chat.request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: chatParameters)
       return try await fetch(debugEnabled: debugEnabled, type: ChatCompletionObject.self, with: request)
    }
 
@@ -93,7 +100,7 @@ struct AIProxyService: OpenAIService {
       var chatParameters = parameters
       chatParameters.stream = true
       chatParameters.streamOptions = .init(includeUsage: true)
-      let request = try await OpenAIAPI.chat.request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: chatParameters)
+      let request = try await OpenAIAPI.chat.request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: chatParameters)
       return try await fetchStream(debugEnabled: debugEnabled, type: ChatCompletionChunkObject.self, with: request)
    }
 
@@ -103,7 +110,7 @@ struct AIProxyService: OpenAIService {
       parameters: EmbeddingParameter)
       async throws -> OpenAIResponse<EmbeddingObject>
    {
-      let request = try await OpenAIAPI.embeddings.request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
+      let request = try await OpenAIAPI.embeddings.request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<EmbeddingObject>.self, with: request)
    }
 
@@ -113,7 +120,7 @@ struct AIProxyService: OpenAIService {
       parameters: FineTuningJobParameters)
       async throws -> FineTuningJobObject
    {
-      let request = try await OpenAIAPI.fineTuning(.create).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
+      let request = try await OpenAIAPI.fineTuning(.create).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(debugEnabled: debugEnabled, type: FineTuningJobObject.self, with: request)
    }
 
@@ -131,7 +138,7 @@ struct AIProxyService: OpenAIService {
          queryItems = [.init(name: "limit", value: "\(limit)")]
       }
 
-      let request = try await OpenAIAPI.fineTuning(.list).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems)
+      let request = try await OpenAIAPI.fineTuning(.list).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<FineTuningJobObject>.self, with: request)
    }
 
@@ -139,7 +146,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> FineTuningJobObject
    {
-      let request = try await OpenAIAPI.fineTuning(.retrieve(jobID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get)
+      let request = try await OpenAIAPI.fineTuning(.retrieve(jobID: id)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get)
       return try await fetch(debugEnabled: debugEnabled, type: FineTuningJobObject.self, with: request)
    }
 
@@ -147,7 +154,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> FineTuningJobObject
    {
-      let request = try await OpenAIAPI.fineTuning(.cancel(jobID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post)
+      let request = try await OpenAIAPI.fineTuning(.cancel(jobID: id)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post)
       return try await fetch(debugEnabled: debugEnabled, type: FineTuningJobObject.self, with: request)
    }
 
@@ -165,7 +172,7 @@ struct AIProxyService: OpenAIService {
       } else if let limit {
          queryItems = [.init(name: "limit", value: "\(limit)")]
       }
-      let request = try await OpenAIAPI.fineTuning(.events(jobID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems)
+      let request = try await OpenAIAPI.fineTuning(.events(jobID: id)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<FineTuningJobEventObject>.self, with: request)
    }
 
@@ -174,7 +181,7 @@ struct AIProxyService: OpenAIService {
    func listFiles()
       async throws -> OpenAIResponse<FileObject>
    {
-      let request = try await OpenAIAPI.file(.list).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get)
+      let request = try await OpenAIAPI.file(.list).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<FileObject>.self, with: request)
    }
 
@@ -182,7 +189,7 @@ struct AIProxyService: OpenAIService {
       parameters: FileParameters)
       async throws -> FileObject
    {
-      let request = try await OpenAIAPI.file(.upload).multiPartRequest(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
+      let request = try await OpenAIAPI.file(.upload).multiPartRequest(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(debugEnabled: debugEnabled, type: FileObject.self, with: request)
    }
 
@@ -190,7 +197,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> DeletionStatus
    {
-      let request = try await OpenAIAPI.file(.delete(fileID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .delete)
+      let request = try await OpenAIAPI.file(.delete(fileID: id)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .delete)
       return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
    }
 
@@ -198,7 +205,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> FileObject
    {
-      let request = try await OpenAIAPI.file(.retrieve(fileID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get)
+      let request = try await OpenAIAPI.file(.retrieve(fileID: id)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get)
       return try await fetch(debugEnabled: debugEnabled, type: FileObject.self, with: request)
    }
 
@@ -206,7 +213,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> [[String: Any]]
    {
-      let request = try await OpenAIAPI.file(.retrieveFileContent(fileID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get)
+      let request = try await OpenAIAPI.file(.retrieveFileContent(fileID: id)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get)
       return try await fetchContentsOfFile(request: request)
    }
 
@@ -216,7 +223,7 @@ struct AIProxyService: OpenAIService {
       parameters: ImageCreateParameters)
       async throws -> OpenAIResponse<ImageObject>
    {
-      let request = try await OpenAIAPI.images(.generations).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
+      let request = try await OpenAIAPI.images(.generations).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<ImageObject>.self,  with: request)
    }
 
@@ -224,7 +231,7 @@ struct AIProxyService: OpenAIService {
       parameters: ImageEditParameters)
       async throws -> OpenAIResponse<ImageObject>
    {
-      let request = try await OpenAIAPI.images(.edits).multiPartRequest(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
+      let request = try await OpenAIAPI.images(.edits).multiPartRequest(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<ImageObject>.self, with: request)
    }
 
@@ -232,7 +239,7 @@ struct AIProxyService: OpenAIService {
       parameters: ImageVariationParameters)
       async throws -> OpenAIResponse<ImageObject>
    {
-      let request = try await OpenAIAPI.images(.variations).multiPartRequest(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
+      let request = try await OpenAIAPI.images(.variations).multiPartRequest(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<ImageObject>.self, with: request)
    }
 
@@ -241,7 +248,7 @@ struct AIProxyService: OpenAIService {
    func listModels()
       async throws -> OpenAIResponse<ModelObject>
    {
-      let request = try await OpenAIAPI.model(.list).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get)
+      let request = try await OpenAIAPI.model(.list).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<ModelObject>.self,  with: request)
    }
 
@@ -249,7 +256,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> ModelObject
    {
-      let request = try await OpenAIAPI.model(.retrieve(modelID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get)
+      let request = try await OpenAIAPI.model(.retrieve(modelID: id)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get)
       return try await fetch(debugEnabled: debugEnabled, type: ModelObject.self,  with: request)
    }
 
@@ -257,7 +264,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> DeletionStatus
    {
-      let request = try await OpenAIAPI.model(.deleteFineTuneModel(modelID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .delete)
+      let request = try await OpenAIAPI.model(.deleteFineTuneModel(modelID: id)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .delete)
       return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self,  with: request)
    }
 
@@ -267,7 +274,7 @@ struct AIProxyService: OpenAIService {
       parameters: ModerationParameter<String>)
       async throws -> ModerationObject
    {
-      let request = try await OpenAIAPI.moderations.request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
+      let request = try await OpenAIAPI.moderations.request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(debugEnabled: debugEnabled, type: ModerationObject.self, with: request)
    }
 
@@ -275,7 +282,7 @@ struct AIProxyService: OpenAIService {
       parameters: ModerationParameter<[String]>)
       async throws -> ModerationObject
    {
-      let request = try await OpenAIAPI.moderations.request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
+      let request = try await OpenAIAPI.moderations.request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(debugEnabled: debugEnabled, type: ModerationObject.self, with: request)
    }
 
@@ -285,7 +292,7 @@ struct AIProxyService: OpenAIService {
       parameters: AssistantParameters)
       async throws -> AssistantObject
    {
-      let request = try await OpenAIAPI.assistant(.create).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.assistant(.create).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: AssistantObject.self, with: request)
    }
 
@@ -293,7 +300,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> AssistantObject
    {
-      let request = try await OpenAIAPI.assistant(.retrieve(assistantID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.assistant(.retrieve(assistantID: id)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: AssistantObject.self, with: request)
    }
 
@@ -302,7 +309,7 @@ struct AIProxyService: OpenAIService {
       parameters: AssistantParameters)
       async throws -> AssistantObject
    {
-      let request = try await OpenAIAPI.assistant(.modify(assistantID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.assistant(.modify(assistantID: id)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: AssistantObject.self, with: request)
    }
 
@@ -310,7 +317,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> DeletionStatus
    {
-      let request = try await OpenAIAPI.assistant(.delete(assistantID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.assistant(.delete(assistantID: id)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
    }
 
@@ -334,7 +341,7 @@ struct AIProxyService: OpenAIService {
       if let before {
          queryItems.append(.init(name: "before", value: before))
       }
-      let request = try await OpenAIAPI.assistant(.list).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.assistant(.list).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<AssistantObject>.self, with: request)
    }
 
@@ -344,14 +351,14 @@ struct AIProxyService: OpenAIService {
       parameters: CreateThreadParameters)
       async throws -> ThreadObject
    {
-      let request = try await OpenAIAPI.thread(.create).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.thread(.create).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: ThreadObject.self, with: request)
    }
 
    func retrieveThread(id: String)
       async throws -> ThreadObject
    {
-      let request = try await OpenAIAPI.thread(.retrieve(threadID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.thread(.retrieve(threadID: id)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: ThreadObject.self, with: request)
    }
 
@@ -360,7 +367,7 @@ struct AIProxyService: OpenAIService {
       parameters: ModifyThreadParameters)
       async throws -> ThreadObject
    {
-      let request = try await OpenAIAPI.thread(.modify(threadID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.thread(.modify(threadID: id)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: ThreadObject.self, with: request)
    }
 
@@ -368,7 +375,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> DeletionStatus
    {
-      let request = try await OpenAIAPI.thread(.delete(threadID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.thread(.delete(threadID: id)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
    }
 
@@ -379,7 +386,7 @@ struct AIProxyService: OpenAIService {
       parameters: MessageParameter)
       async throws -> MessageObject
    {
-      let request = try await OpenAIAPI.message(.create(threadID: threadID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.message(.create(threadID: threadID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: MessageObject.self, with: request)
    }
 
@@ -388,7 +395,7 @@ struct AIProxyService: OpenAIService {
       messageID: String)
       async throws -> MessageObject
    {
-      let request = try await OpenAIAPI.message(.retrieve(threadID: threadID, messageID: messageID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.message(.retrieve(threadID: threadID, messageID: messageID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: MessageObject.self, with: request)
    }
 
@@ -398,7 +405,7 @@ struct AIProxyService: OpenAIService {
       parameters: ModifyMessageParameters)
       async throws -> MessageObject
    {
-      let request = try await OpenAIAPI.message(.modify(threadID: threadID, messageID: messageID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.message(.modify(threadID: threadID, messageID: messageID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: MessageObject.self, with: request)
    }
 
@@ -424,7 +431,7 @@ struct AIProxyService: OpenAIService {
       if let before {
          queryItems.append(.init(name: "before", value: before))
       }
-      let request = try await OpenAIAPI.message(.list(threadID: threadID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.message(.list(threadID: threadID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<MessageObject>.self, with: request)
    }
 
@@ -435,7 +442,7 @@ struct AIProxyService: OpenAIService {
       parameters: RunParameter)
       async throws -> RunObject
    {
-      let request = try await OpenAIAPI.run(.create(threadID: threadID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.run(.create(threadID: threadID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
    }
 
@@ -444,7 +451,7 @@ struct AIProxyService: OpenAIService {
       runID: String)
       async throws -> RunObject
    {
-      let request = try await OpenAIAPI.run(.retrieve(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.run(.retrieve(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
    }
 
@@ -454,7 +461,7 @@ struct AIProxyService: OpenAIService {
       parameters: ModifyRunParameters)
       async throws -> RunObject
    {
-      let request = try await OpenAIAPI.run(.modify(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.run(.modify(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
    }
 
@@ -479,7 +486,7 @@ struct AIProxyService: OpenAIService {
       if let before {
          queryItems.append(.init(name: "before", value: before))
       }
-      let request = try await OpenAIAPI.run(.list(threadID: threadID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.run(.list(threadID: threadID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<RunObject>.self, with: request)
    }
 
@@ -488,7 +495,7 @@ struct AIProxyService: OpenAIService {
       runID: String)
       async throws -> RunObject
    {
-      let request = try await OpenAIAPI.run(.cancel(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.run(.cancel(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
    }
 
@@ -498,7 +505,7 @@ struct AIProxyService: OpenAIService {
       parameters: RunToolsOutputParameter)
       async throws -> RunObject
    {
-      let request = try await OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
    }
 
@@ -506,7 +513,7 @@ struct AIProxyService: OpenAIService {
       parameters: CreateThreadAndRunParameter)
       async throws -> RunObject
    {
-      let request = try await OpenAIAPI.run(.createThreadAndRun).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
+      let request = try await OpenAIAPI.run(.createThreadAndRun).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
    }
 
@@ -518,7 +525,7 @@ struct AIProxyService: OpenAIService {
       stepID: String)
       async throws -> RunStepObject
    {
-      let request = try await OpenAIAPI.runStep(.retrieve(threadID: threadID, runID: runID, stepID: stepID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.runStep(.retrieve(threadID: threadID, runID: runID, stepID: stepID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: RunStepObject.self, with: request)
    }
 
@@ -544,7 +551,7 @@ struct AIProxyService: OpenAIService {
       if let before {
          queryItems.append(.init(name: "before", value: before))
       }
-      let request = try await OpenAIAPI.runStep(.list(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.runStep(.list(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<RunStepObject>.self, with: request)
    }
 
@@ -555,7 +562,7 @@ struct AIProxyService: OpenAIService {
    {
       var runParameters = parameters
       runParameters.stream = true
-      let request = try await OpenAIAPI.run(.create(threadID: threadID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: runParameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.run(.create(threadID: threadID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: runParameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetchAssistantStreamEvents(with: request, debugEnabled: debugEnabled)
    }
 
@@ -564,7 +571,7 @@ struct AIProxyService: OpenAIService {
       async throws -> AsyncThrowingStream<AssistantStreamEvent, Error> {
       var runParameters = parameters
       runParameters.stream = true
-      let request = try await OpenAIAPI.run(.createThreadAndRun).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
+      let request = try await OpenAIAPI.run(.createThreadAndRun).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
          return try await fetchAssistantStreamEvents(with: request, debugEnabled: debugEnabled)
    }
 
@@ -576,7 +583,7 @@ struct AIProxyService: OpenAIService {
    {
       var runToolsOutputParameter = parameters
       runToolsOutputParameter.stream = true
-      let request = try await OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: runToolsOutputParameter, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: runToolsOutputParameter, betaHeaderField: Self.assistantsBetaV2)
       return try await fetchAssistantStreamEvents(with: request, debugEnabled: debugEnabled)
    }
 
@@ -586,7 +593,7 @@ struct AIProxyService: OpenAIService {
       parameters: BatchParameter)
       async throws -> BatchObject
    {
-      let request = try await OpenAIAPI.batch(.create).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
+      let request = try await OpenAIAPI.batch(.create).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(debugEnabled: debugEnabled, type: BatchObject.self, with: request)
    }
 
@@ -594,7 +601,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> BatchObject
    {
-      let request = try await OpenAIAPI.batch(.retrieve(batchID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get)
+      let request = try await OpenAIAPI.batch(.retrieve(batchID: id)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get)
       return try await fetch(debugEnabled: debugEnabled, type: BatchObject.self, with: request)
    }
 
@@ -602,7 +609,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> BatchObject
    {
-      let request = try await OpenAIAPI.batch(.cancel(batchID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post)
+      let request = try await OpenAIAPI.batch(.cancel(batchID: id)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post)
       return try await fetch(debugEnabled: debugEnabled, type: BatchObject.self, with: request)
    }
 
@@ -618,7 +625,7 @@ struct AIProxyService: OpenAIService {
       if let after {
          queryItems.append(.init(name: "after", value: after))
       }
-      let request = try await OpenAIAPI.batch(.list).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems)
+      let request = try await OpenAIAPI.batch(.list).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<BatchObject>.self, with: request)
    }
 
@@ -628,7 +635,7 @@ struct AIProxyService: OpenAIService {
       parameters: VectorStoreParameter)
       async throws -> VectorStoreObject
    {
-      let request = try await OpenAIAPI.vectorStore(.create).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.vectorStore(.create).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreObject.self, with: request)
    }
 
@@ -652,7 +659,7 @@ struct AIProxyService: OpenAIService {
       if let before {
          queryItems.append(.init(name: "before", value: before))
       }
-      let request = try await OpenAIAPI.vectorStore(.list).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.vectorStore(.list).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<VectorStoreObject>.self, with: request)
    }
 
@@ -660,7 +667,7 @@ struct AIProxyService: OpenAIService {
       id: String) async throws
       -> VectorStoreObject
    {
-      let request = try await OpenAIAPI.vectorStore(.retrieve(vectorStoreID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.vectorStore(.retrieve(vectorStoreID: id)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreObject.self, with: request)
    }
 
@@ -669,7 +676,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> VectorStoreObject
    {
-      let request = try await OpenAIAPI.vectorStore(.modify(vectorStoreID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.vectorStore(.modify(vectorStoreID: id)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreObject.self, with: request)
    }
 
@@ -677,7 +684,7 @@ struct AIProxyService: OpenAIService {
       id: String)
       async throws -> DeletionStatus
    {
-      let request = try await OpenAIAPI.vectorStore(.modify(vectorStoreID: id)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.vectorStore(.modify(vectorStoreID: id)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
    }
 
@@ -688,7 +695,7 @@ struct AIProxyService: OpenAIService {
       parameters: VectorStoreFileParameter)
       async throws -> VectorStoreFileObject
    {
-      let request = try await OpenAIAPI.vectorStore(.create).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.vectorStore(.create).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreFileObject.self, with: request)
    }
 
@@ -717,7 +724,7 @@ struct AIProxyService: OpenAIService {
       if let filter {
          queryItems.append(.init(name: "filter", value: filter))
       }
-      let request = try await OpenAIAPI.vectorStoreFile(.list(vectorStoreID: vectorStoreID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.vectorStoreFile(.list(vectorStoreID: vectorStoreID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<VectorStoreFileObject>.self, with: request)
    }
 
@@ -726,7 +733,7 @@ struct AIProxyService: OpenAIService {
       fileID: String)
       async throws -> VectorStoreFileObject
    {
-      let request = try await OpenAIAPI.vectorStoreFile(.retrieve(vectorStoreID: vectorStoreID, fileID: fileID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.vectorStoreFile(.retrieve(vectorStoreID: vectorStoreID, fileID: fileID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreFileObject.self, with: request)
    }
 
@@ -735,7 +742,7 @@ struct AIProxyService: OpenAIService {
       fileID: String)
       async throws -> DeletionStatus
    {
-      let request = try await OpenAIAPI.vectorStoreFile(.delete(vectorStoreID: vectorStoreID, fileID: fileID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.vectorStoreFile(.delete(vectorStoreID: vectorStoreID, fileID: fileID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
    }
 
@@ -746,7 +753,7 @@ struct AIProxyService: OpenAIService {
       parameters: VectorStoreFileBatchParameter)
       async throws -> VectorStoreFileBatchObject
    {
-      let request = try await OpenAIAPI.vectorStoreFileBatch(.create(vectorStoreID: vectorStoreID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.vectorStoreFileBatch(.create(vectorStoreID: vectorStoreID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreFileBatchObject.self, with: request)
    }
 
@@ -755,7 +762,7 @@ struct AIProxyService: OpenAIService {
       batchID: String)
       async throws -> VectorStoreFileBatchObject
    {
-      let request = try await OpenAIAPI.vectorStoreFileBatch(.retrieve(vectorStoreID: vectorStoreID, batchID: batchID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.vectorStoreFileBatch(.retrieve(vectorStoreID: vectorStoreID, batchID: batchID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreFileBatchObject.self, with: request)
    }
 
@@ -764,7 +771,7 @@ struct AIProxyService: OpenAIService {
       batchID: String)
       async throws -> VectorStoreFileBatchObject
    {
-      let request = try await OpenAIAPI.vectorStoreFileBatch(.cancel(vectorStoreID: vectorStoreID, batchID: batchID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .post, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.vectorStoreFileBatch(.cancel(vectorStoreID: vectorStoreID, batchID: batchID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .post, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreFileBatchObject.self, with: request)
    }
 
@@ -794,7 +801,7 @@ struct AIProxyService: OpenAIService {
       if let filter {
          queryItems.append(.init(name: "filter", value: filter))
       }
-      let request = try await OpenAIAPI.vectorStoreFileBatch(.list(vectorStoreID: vectorStoreID, batchID: batchID)).request(aiproxyPartialKey: partialKey, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
+      let request = try await OpenAIAPI.vectorStoreFileBatch(.list(vectorStoreID: vectorStoreID, batchID: batchID)).request(aiproxyPartialKey: partialKey, serviceURL: serviceURL, clientID: clientID, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<VectorStoreFileObject>.self, with: request)
    }
 }

--- a/Sources/OpenAI/AIProxy/Endpoint+AIProxy.swift
+++ b/Sources/OpenAI/AIProxy/Endpoint+AIProxy.swift
@@ -35,11 +35,13 @@ private let deviceCheckWarning = """
 extension Endpoint {
 
     private func urlComponents(
-       queryItems: [URLQueryItem])
+      serviceURL: String?,
+      queryItems: [URLQueryItem])
        -> URLComponents
     {
-       var components = URLComponents(string: "https://api.aiproxy.pro")!
-       components.path = path
+       // var components = URLComponents(string: serviceURL ?? "https://api.aiproxy.pro")!
+       var components = URLComponents(string: serviceURL ?? "http://Lous-MacBook-Air-3.local:4000")!
+       components.path = components.path.appending(path)
        if !queryItems.isEmpty {
           components.queryItems = queryItems
        }
@@ -48,6 +50,7 @@ extension Endpoint {
 
    func request(
       aiproxyPartialKey: String,
+      serviceURL: String?,
       clientID: String?,
       organizationID: String?,
       method: HTTPMethod,
@@ -56,7 +59,7 @@ extension Endpoint {
       betaHeaderField: String? = nil)
       async throws -> URLRequest
    {
-      var request = URLRequest(url: urlComponents(queryItems: queryItems).url!)
+      var request = URLRequest(url: urlComponents(serviceURL: serviceURL, queryItems: queryItems).url!)
       request.addValue("application/json", forHTTPHeaderField: "Content-Type")
       request.addValue(aiproxyPartialKey, forHTTPHeaderField: "aiproxy-partial-key")
       if let organizationID {
@@ -85,15 +88,16 @@ extension Endpoint {
 
    func multiPartRequest(
       aiproxyPartialKey: String,
+      serviceURL: String?,
       clientID: String?,
       organizationID: String?,
       method: HTTPMethod,
       params: MultipartFormDataParameters,
-      queryItems: [URLQueryItem] = [],
-      deviceCheckBypass: String? = nil)
+      queryItems: [URLQueryItem] = []
+   )
       async throws -> URLRequest
    {
-      var request = URLRequest(url: urlComponents(queryItems: queryItems).url!)
+      var request = URLRequest(url: urlComponents(serviceURL: serviceURL, queryItems: queryItems).url!)
       request.httpMethod = method.rawValue
       request.addValue(aiproxyPartialKey, forHTTPHeaderField: "aiproxy-partial-key")
       if let organizationID {
@@ -106,7 +110,7 @@ extension Endpoint {
           request.addValue(deviceCheckToken, forHTTPHeaderField: "aiproxy-devicecheck")
       }
 #if DEBUG && targetEnvironment(simulator)
-      if let deviceCheckBypass = deviceCheckBypass {
+      if let deviceCheckBypass = ProcessInfo.processInfo.environment["AIPROXY_DEVICE_CHECK_BYPASS"] {
          request.addValue(deviceCheckBypass, forHTTPHeaderField: "aiproxy-devicecheck-bypass")
       }
 #endif

--- a/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
+++ b/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
@@ -70,6 +70,12 @@ public class OpenAIServiceFactory {
    /// - Parameters:
    ///   - aiproxyPartialKey: The partial key provided in the 'API Keys' section of the AIProxy dashboard.
    ///                        Please see the integration guide for acquiring your key, at https://www.aiproxy.pro/docs
+   ///
+   ///   - aiproxyServiceURL: The service URL is displayed in the AIProxy dashboard when you submit your OpenAI key.
+   ///                        This argument is required for keys that you submitted after July 22nd, 2024. If you are an
+   ///                        existing customer that configured your AIProxy project before July 22nd, you may continue
+   ///                        to leave this blank.
+   ///
    ///   - aiproxyClientID: If your app already has client or user IDs that you want to annotate AIProxy requests
    ///                      with, you can pass a clientID here. If you do not have existing client or user IDs, leave
    ///                      the `clientID` argument out, and IDs will be generated automatically for you.
@@ -78,11 +84,14 @@ public class OpenAIServiceFactory {
    /// - Returns: A conformer of OpenAIService that proxies all requests through api.aiproxy.pro
    public static func service(
       aiproxyPartialKey: String,
-      aiproxyClientID: String? = nil, debugEnabled: Bool = false)
+      aiproxyServiceURL: String? = nil,
+      aiproxyClientID: String? = nil,
+      debugEnabled: Bool = false)
    -> some OpenAIService
    {
       AIProxyService(
         partialKey: aiproxyPartialKey,
+        serviceURL: aiproxyServiceURL,
         clientID: aiproxyClientID,
         debugEnabled: debugEnabled
       )


### PR DESCRIPTION
- Starting next week, all AIProxy integrations will require a service URL. Developers each get their own service URL to proxy requests through. The service URL is displayed in the AIProxy dashboard when you configure your project.
- The AIProxy integration code changes from this:

```swift
let service = OpenAIServiceFactory.service(
    aiproxyPartialKey: "your_partial_key_goes_here"
)
```

to this:

```swift
let service = OpenAIServiceFactory.service(
    aiproxyPartialKey: "your_partial_key_goes_here",
    aiproxyServiceURL: "your_service_url_goes_here"
)