### PR TITLE
AIProxy bug fix: Do not fall back to Lou's computer

### DIFF
--- a/Sources/OpenAI/AIProxy/Endpoint+AIProxy.swift
+++ b/Sources/OpenAI/AIProxy/Endpoint+AIProxy.swift
@@ -39,8 +39,7 @@ extension Endpoint {
       queryItems: [URLQueryItem])
        -> URLComponents
     {
-       // var components = URLComponents(string: serviceURL ?? "https://api.aiproxy.pro")!
-       var components = URLComponents(string: serviceURL ?? "http://Lous-MacBook-Air-3.local:4000")!
+       var components = URLComponents(string: serviceURL ?? "https://api.aiproxy.pro")!
        components.path = components.path.appending(path)
        if !queryItems.isEmpty {
           components.queryItems = queryItems


### PR DESCRIPTION
- If the developer does not provide an AIProxy `serviceURL` in their integration, we want to fall back to `api.aiproxy.pro` and not `http://Lous-MacBook-Air-3.local:4000` 😅
- I introduced this bug in https://github.com/jamesrochabrun/SwiftOpenAI/pull/63
