### PR TITLE
Touch up the AIProxy section of README

### DIFF
--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/AIProxyIntroView.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/AIProxyIntroView.swift
@@ -13,6 +13,10 @@ struct AIProxyIntroView: View {
    @State private var partialKey = ""
    @State private var serviceURL = ""
 
+   private var canProceed: Bool {
+      return !(self.partialKey.isEmpty || self.serviceURL.isEmpty)
+   }
+
    var body: some View {
       NavigationStack {
          VStack {
@@ -34,12 +38,12 @@ struct AIProxyIntroView: View {
                   .foregroundColor(.white)
                   .background(
                      Capsule()
-                        .foregroundColor(partialKey.isEmpty ? .gray.opacity(0.2) : Color(red: 64/255, green: 195/255, blue: 125/255)))
+                        .foregroundColor(canProceed ? Color(red: 64/255, green: 195/255, blue: 125/255) : .gray.opacity(0.2)))
             }
-            .disabled(partialKey.isEmpty)
+            .disabled(!canProceed)
             Spacer()
             Group {
-               Text("You can now use SwiftOpenAI for development and production! AIProxy keeps your OpenAI API key secure. To configure AIProxy for your project, or to learn more about how it works, please see the docs at ") + Text("[this link](https://www.aiproxy.pro/docs).")
+               Text("AIProxy keeps your OpenAI API key secure. To configure AIProxy for your project, or to learn more about how it works, please see the docs at ") + Text("[this link](https://www.aiproxy.pro/docs).")
             }
             .font(.caption)
          }

--- a/README.md
+++ b/README.md
@@ -3012,13 +3012,14 @@ let completionObject = try await service.startChat(parameters: parameters)
 
 ### What is it?
 
-[AIProxy](https://www.aiproxy.pro) is a backend for AI apps that proxies requests from your app to OpenAI.
-You can use this service to avoid exposing your OpenAI key in your app.
-We offer AIProxy support so that developers can build **and** distribute apps using SwiftOpenAI.  
+[AIProxy](https://www.aiproxy.pro) is a backend for iOS apps that proxies requests from your app to OpenAI.
+Using a proxy keeps your OpenAI key secret, protecting you from unexpectedly high bills due to key theft.
+Requests are only proxied if they pass your defined rate limits and Apple's [DeviceCheck](https://developer.apple.com/documentation/devicecheck) verification.
+We offer AIProxy support so you can safely distribute apps built with SwiftOpenAI.
 
 ### How does my SwiftOpenAI code change?
 
-SwiftOpenAI supports proxying requests through AIProxy with two changes to your Xcode project:
+Proxy requests through AIProxy with two changes to your Xcode project:
 
 1. Instead of initializing `service` with:
 
@@ -3059,10 +3060,10 @@ thus remove one level of protection.
 
 #### What is the `aiproxyPartialKey` constant?
 
-This constant is intended to be **included** in the distributed version of your app. As the name implies, it is a
-partial representation of your OpenAI key. Specifically, it is one half of an encrypted version of your key.
-The other half resides on AIProxy's backend. As your app makes requests to AIProxy, the two encrypted parts
-are paired, decrypted, and used to fulfill the request to OpenAI.
+This constant is safe to include in distributed version of your app. It is one part of an
+encrypted representation of your real secret key. The other part resides on AIProxy's backend.
+As your app makes requests to AIProxy, the two encrypted parts are paired, decrypted, and used
+to fulfill the request to OpenAI.
 
 #### How to setup my project on AIProxy?
 

--- a/Sources/OpenAI/AIProxy/AIProxyService.swift
+++ b/Sources/OpenAI/AIProxy/AIProxyService.swift
@@ -15,8 +15,6 @@ struct AIProxyService: OpenAIService {
    let session: URLSession
    let decoder: JSONDecoder
 
-   private let sessionID = UUID().uuidString
-
    /// Your partial key is provided during the integration process at dashboard.aiproxy.pro
    /// Please see the [integration guide](https://www.aiproxy.pro/docs/integration-guide.html) for acquiring your partial key
    private let partialKey: String


### PR DESCRIPTION
- Made the AIProxy section of the readme consistent with SwiftAnthropic's readme
- Added a `canProceed` helper to the intro view that ensures both the serviceURL and partialKey are entered by the user