### PR TITLE
Remove 'some' from factory return type

### DIFF
--- a/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
+++ b/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
@@ -27,7 +27,7 @@ public class OpenAIServiceFactory {
       configuration: URLSessionConfiguration = .default,
       decoder: JSONDecoder = .init(),
       debugEnabled: Bool = false)
-      -> some OpenAIService
+      -> OpenAIService
    {
       DefaultOpenAIService(
          apiKey: apiKey,
@@ -53,7 +53,7 @@ public class OpenAIServiceFactory {
       urlSessionConfiguration: URLSessionConfiguration = .default,
       decoder: JSONDecoder = .init(),
       debugEnabled: Bool = false)
-   -> some OpenAIService
+   -> OpenAIService
    {
       DefaultOpenAIAzureService(
          azureConfiguration: azureConfiguration,
@@ -87,7 +87,7 @@ public class OpenAIServiceFactory {
       aiproxyServiceURL: String? = nil,
       aiproxyClientID: String? = nil,
       debugEnabled: Bool = false)
-   -> some OpenAIService
+   -> OpenAIService
    {
       AIProxyService(
         partialKey: aiproxyPartialKey,
@@ -114,7 +114,7 @@ public class OpenAIServiceFactory {
       apiKey: Authorization = .apiKey(""),
       baseURL: String,
       debugEnabled: Bool = false)
-      -> some OpenAIService
+      -> OpenAIService
    {
       LocalModelService(
          apiKey: apiKey,


### PR DESCRIPTION
When trying to set the service as a member on a type, you can hit the compilation error: 

```
Property definition has inferred type 'some OpenAIService', involving the 'some' return type of another declaration
```

To work around the compilation error, I could specify `let service: some OpenAIService = ...`. A better fix, though, is to remove the `some` keyword on the factory methods. We don't need `some` here, because the protocol that our concrete types are conforming to is not a PAT. We don't need to use 'reverse generics' and can instead just rely on vanilla polymorphism through protocols.

![Screenshot 2024-08-06 at 09 25 12](https://github.com/user-attachments/assets/b0d8c08d-09ad-4c45-a1e9-827cfac7aaef)

