### PR TITLE
Updating READ.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -1211,7 +1211,7 @@ let tool = ChatCompletionParameters.Tool(
             function: .init(
                name: "math_response,
                strict: true,
-               parameters: mathResponseSchema)
+               parameters: mathResponseSchema))
 )
 
 let prompt = "solve 8x + 31 = 2"
@@ -1278,11 +1278,11 @@ let parameters = ChatCompletionParameters(
 
 SwiftOpenAI Structred outputs supports:
 
-[x] Tools Structured output.
-[x] Response format Structure output.
-[x] Recursive Schema.
-[x] Optional values Schema.
-[ ] Pydantic models.
+- [x] Tools Structured output.
+- [x] Response format Structure output.
+- [x] Recursive Schema.
+- [x] Optional values Schema.
+- [ ] Pydantic models.
 
 We don't support Pydantic models, users need tos manually create Schemas using `JSONSchema` or `JSONSchemaResponseFormat` objects.
 

--- a/README.md
+++ b/README.md
@@ -1282,6 +1282,9 @@ SwiftOpenAI Structred outputs supports:
 [x] Response format Structure output.
 [x] Recursive Schema.
 [x] Optional values Schema.
+[ ] Pydantic models.
+
+We don't support Pydantic models, users need tos manually create Schemas using `JSONSchema` or `JSONSchemaResponseFormat` objects.
 
 For more details visit the Demo project for [tools](https://github.com/jamesrochabrun/SwiftOpenAI/tree/main/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ChatStructureOutputTool) and [response format](https://github.com/jamesrochabrun/SwiftOpenAI/tree/main/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ChatStructuredOutputs).
 

--- a/README.md
+++ b/README.md
@@ -1118,8 +1118,8 @@ For more details about how to also uploading base 64 encoded images in iOS check
 #### Documentation:
 
 - [Structured Outputs Guides](https://platform.openai.com/docs/guides/structured-outputs/structured-outputs)
-- [Examples](https://platform.openai.com/docs/guides/structured-outputs/examples))
-- [How to use](https://platform.openai.com/docs/guides/structured-outputs/how-to-use))
+- [Examples](https://platform.openai.com/docs/guides/structured-outputs/examples)
+- [How to use](https://platform.openai.com/docs/guides/structured-outputs/how-to-use)
 - [Supported schemas](https://platform.openai.com/docs/guides/structured-outputs/supported-schemas)
 
 Must knowns:
@@ -1216,7 +1216,7 @@ let tool = ChatCompletionParameters.Tool(
 
 let prompt = "solve 8x + 31 = 2"
 let systemMessage = ChatCompletionParameters.Message(role: .system, content: .text("You are a math tutor"))
-let userMessage = ChatCompletionParameters.Message(role: .user, content: .text("prompt"))
+let userMessage = ChatCompletionParameters.Message(role: .user, content: .text(prompt))
 let parameters = ChatCompletionParameters(
    messages: [systemMessage, userMessage],
    model: .gpt4o20240806,
@@ -1269,7 +1269,7 @@ let responseFormatSchema = JSONSchemaResponseFormat(
 
 let prompt = "solve 8x + 31 = 2"
 let systemMessage = ChatCompletionParameters.Message(role: .system, content: .text("You are a math tutor"))
-let userMessage = ChatCompletionParameters.Message(role: .user, content: .text("prompt"))
+let userMessage = ChatCompletionParameters.Message(role: .user, content: .text(prompt))
 let parameters = ChatCompletionParameters(
    messages: [systemMessage, userMessage],
    model: .gpt4o20240806,


### PR DESCRIPTION
#### How to use Structured Outputs

1. Function calling: Structured Outputs via tools is available by setting strict: true within your function definition. This feature works with all models that support tools, including all models gpt-4-0613 and gpt-3.5-turbo-0613 and later. When Structured Outputs are enabled, model outputs will match the supplied tool definition.

Using this schema:

```json
{
  "schema": {
    "type": "object",
    "properties": {
      "steps": {
        "type": "array",
        "items": {
          "type": "object",
          "properties": {
            "explanation": {
              "type": "string"
            },
            "output": {
              "type": "string"
            }
          },
          "required": ["explanation", "output"],
          "additionalProperties": false
        }
      },
      "final_answer": {
        "type": "string"
      }
    },
    "required": ["steps", "final_answer"],
    "additionalProperties": false
  }
}
```

You can use the convenient `JSONSchema` object like this:

```swift
// 1: Define the Step schema object

let stepSchema = JSONSchema(
   type: .object,
   properties: [
      "explanation": JSONSchema(type: .string),
      "output": JSONSchema(
         type: .string)
   ],
   required: ["explanation", "output"],
   additionalProperties: false
)

// 2. Define the steps Array schema.

let stepsArraySchema = JSONSchema(type: .array, items: stepSchema)

// 3. Define the final Answer schema.

let finalAnswerSchema = JSONSchema(type: .string)

// 4. Define math reponse JSON schema.

let mathResponseSchema = JSONSchema(
      type: .object,
      properties: [
         "steps": stepsArraySchema,
         "final_answer": finalAnswerSchema
      ],
      required: ["steps", "final_answer"],
      additionalProperties: false
)

let tool = ChatCompletionParameters.Tool(
            function: .init(
               name: "math_response",
               strict: true,
               parameters: mathResponseSchema)
)

let prompt = "solve 8x + 31 = 2"
let systemMessage = ChatCompletionParameters.Message(role: .system, content: .text("You are a math tutor"))
let userMessage = ChatCompletionParameters.Message(role: .user, content: .text(prompt))
let parameters = ChatCompletionParameters(
   messages: [systemMessage, userMessage],
   model: .gpt4o20240806,
   tools: [tool])

let chat = try await service.startChat(parameters: parameters)
```

2. A new option for the `response_format` parameter: developers can now supply a JSON Schema via `json_schema`, a new option for the response_format parameter. This is useful when the model is not calling a tool, but rather, responding to the user in a structured way. This feature works with our newest GPT-4o models: `gpt-4o-2024-08-06`, released today, and `gpt-4o-mini-2024-07-18`. When a response_format is supplied with strict: true, model outputs will match the supplied schema.

Using the previous schema, this is how you can implement it as json schema using the convenient `JSONSchemaResponseFormat` object:

```swift
// 1: Define the Step schema object

let stepSchema = JSONSchema(
   type: .object,
   properties: [
      "explanation": JSONSchema(type: .string),
      "output": JSONSchema(
         type: .string)
   ],
   required: ["explanation", "output"],
   additionalProperties: false
)

// 2. Define the steps Array schema.

let stepsArraySchema = JSONSchema(type: .array, items: stepSchema)

// 3. Define the final Answer schema.

let finalAnswerSchema = JSONSchema(type: .string)

// 4. Define the response format JSON schema.

let responseFormatSchema = JSONSchemaResponseFormat(
   name: "math_response",
   strict: true,
   schema: JSONSchema(
      type: .object,
      properties: [
         "steps": stepsArraySchema,
         "final_answer": finalAnswerSchema
      ],
      required: ["steps", "final_answer"],
      additionalProperties: false
   )
)

let prompt = "solve 8x + 31 = 2"
let systemMessage = ChatCompletionParameters.Message(role: .system, content: .text("You are a math tutor"))
let userMessage = ChatCompletionParameters.Message(role: .user, content: .text(prompt))
let parameters = ChatCompletionParameters(
   messages: [systemMessage, userMessage],
   model: .gpt4o20240806,
   responseFormat: .jsonSchema(responseFormatSchema))
```

SwiftOpenAI Structred outputs supports:

- [x] Tools Structured output.
- [x] Response format Structure output.
- [x] Recursive Schema.
- [x] Optional values Schema.
- [ ] Pydantic models.

We don't support Pydantic models, users need tos manually create Schemas using `JSONSchema` or `JSONSchemaResponseFormat` objects.

For more details visit the Demo project for [tools](https://github.com/jamesrochabrun/SwiftOpenAI/tree/main/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ChatStructureOutputTool) and [response format](https://github.com/jamesrochabrun/SwiftOpenAI/tree/main/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ChatStructuredOutputs).