### PR TITLE
Fix decoding error triggered by Assistants API responses with data from searching a vector database

### DIFF
--- a/Sources/OpenAI/Public/ResponseModels/Messages/MessageContent.swift
+++ b/Sources/OpenAI/Public/ResponseModels/Messages/MessageContent.swift
@@ -148,13 +148,13 @@ public enum Annotation: Codable {
 /// A citation within the message that points to a specific quote from a specific File associated with the assistant or the message. Generated when the assistant uses the "retrieval" tool to search files.
 public struct FileCitation: Codable {
    
-   /// Always file_citation.
-   public let type: String
-   /// The text in the message content that needs to be replaced.
-   public let text: String
-   public let fileCitation: FileCitationDetails
-   public let startIndex: Int
-   public let endIndex: Int
+   /// Always file_citation, except when using Assistants API Beta, e.g. when using file_store search
+   public let type: String?
+   /// The text in the message content that needs to be replaced. Not always present with Assistants API Beta, e.g. when using file_store search
+   public let text: String?
+   public let fileCitation: FileCitationDetails?
+   public let startIndex: Int?
+   public let endIndex: Int?
    
    public struct FileCitationDetails: Codable {
       


### PR DESCRIPTION
When the Assistants API is asked to search a file store, it replies with a response that does not include properties required by the MessageObject's CodingKeys. This leads to a decoding error. This PR makes those values optional so that:

1. Current Assistants API responses that are successfully decoded are still decoded successfully
2. Assistants API responses with data from a file_search, which do not contain `FileCitation.type`, `FileCitation.text`, `FileCitation.startIndex`, and `FileCitation.endIndex`, also work

**TEST PLAN**
1. Create an Assistant AI in OpenAI and note its `agent_id`. Attach a file store with at least one text file.
2. Create a skeleton project that utilizes SwiftOpenAI's current `main` branch to handle an Assistant interaction, such as in a conversation.
3. Create a thread with the assistant and send a message, such as "May I ask you a question?"
4. Note that the response is decoded successfully to an in-memory representation of the OpenAI Response.
5. Now send a message such as "Please search your file store for advice on how to decode API responses."
6. Note the CodingKeys error.
7. Now switch to this branch. Perform steps 3-5. Note there are no errors and that the client can now receive responses that contain file citations from the Assistant.