### PR TITLE
Adding additional parameters in API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,6 @@ An open-source Swift package designed for effortless interaction with OpenAI's p
 - [Installation](#installation)
 - [Compatibility](#compatibility)
 - [Usage](#usage)
-- [Azure OpenAI](#azure-openai)
-- [AIProxy](#aiproxy)
-- [Ollama](#ollama)
-- [Groq](#groq)
-
 - [Collaboration](#collaboration)
 
 ## Description
@@ -105,9 +100,11 @@ to stay on the bleeding edge.
 
 SwiftOpenAI supports various providers that are OpenAI-compatible, including but not limited to:
 
+- [Azure OpenAI](#azure-openai)
+- [Gemini](#gemini)
 - [Ollama](#ollama)
 - [Groq](#groq)
-- [Gemini](#gemini)
+- [AIProxy](#aiproxy)
 
 Check OpenAIServiceFactory for convenience initializers that you can use to provide custom URLs.
 

--- a/Sources/OpenAI/Public/Service/DefaultOpenAIService.swift
+++ b/Sources/OpenAI/Public/Service/DefaultOpenAIService.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  DefaultOpenAIService.swift
+//
 //
 //  Created by James Rochabrun on 10/17/23.
 //
@@ -19,6 +19,8 @@ struct DefaultOpenAIService: OpenAIService {
    private let organizationID: String?
    /// Set this flag to TRUE if you need to print request events in DEBUG builds.
    private let debugEnabled: Bool
+   /// Extra headers for the request.
+   private let extraHeaders: [String: String]?
    
    private static let assistantsBetaV2 = "assistants=v2"
    
@@ -28,6 +30,7 @@ struct DefaultOpenAIService: OpenAIService {
       baseURL: String? = nil,
       proxyPath: String? = nil,
       overrideVersion: String? = nil,
+      extraHeaders: [String: String]? = nil,
       configuration: URLSessionConfiguration = .default,
       decoder: JSONDecoder = .init(),
       debugEnabled: Bool)
@@ -36,6 +39,7 @@ struct DefaultOpenAIService: OpenAIService {
       self.decoder = decoder
       self.apiKey = .bearer(apiKey)
       self.organizationID = organizationID
+      self.extraHeaders = extraHeaders
       OpenAIAPI.overrideBaseURL = baseURL
       OpenAIAPI.proxyPath = proxyPath
       OpenAIAPI.overrideVersion = overrideVersion
@@ -64,7 +68,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: AudioSpeechParameters)
       async throws -> AudioSpeechObject
    {
-      let request = try OpenAIAPI.audio(.speech).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters)
+      let request = try OpenAIAPI.audio(.speech).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
       let data = try await fetchAudio(with: request)
       return AudioSpeechObject(output: data)
    }
@@ -77,7 +81,7 @@ struct DefaultOpenAIService: OpenAIService {
    {
       var chatParameters = parameters
       chatParameters.stream = false
-      let request = try OpenAIAPI.chat.request(apiKey: apiKey, organizationID: organizationID, method: .post, params: chatParameters)
+      let request = try OpenAIAPI.chat.request(apiKey: apiKey, organizationID: organizationID, method: .post, params: chatParameters, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: ChatCompletionObject.self, with: request)
    }
    
@@ -87,7 +91,7 @@ struct DefaultOpenAIService: OpenAIService {
    {
       var chatParameters = parameters
       chatParameters.stream = true
-      let request = try OpenAIAPI.chat.request(apiKey: apiKey, organizationID: organizationID, method: .post, params: chatParameters)
+      let request = try OpenAIAPI.chat.request(apiKey: apiKey, organizationID: organizationID, method: .post, params: chatParameters, extraHeaders: extraHeaders)
       return try await fetchStream(debugEnabled: debugEnabled, type: ChatCompletionChunkObject.self, with: request)
    }
    
@@ -97,7 +101,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: EmbeddingParameter)
       async throws -> OpenAIResponse<EmbeddingObject>
    {
-      let request = try OpenAIAPI.embeddings.request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters)
+      let request = try OpenAIAPI.embeddings.request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<EmbeddingObject>.self, with: request)
    }
    
@@ -107,7 +111,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: FineTuningJobParameters)
       async throws -> FineTuningJobObject
    {
-      let request = try OpenAIAPI.fineTuning(.create).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters)
+      let request = try OpenAIAPI.fineTuning(.create).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: FineTuningJobObject.self, with: request)
    }
    
@@ -125,7 +129,7 @@ struct DefaultOpenAIService: OpenAIService {
          queryItems = [.init(name: "limit", value: "\(limit)")]
       }
       
-      let request = try OpenAIAPI.fineTuning(.list).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems)
+      let request = try OpenAIAPI.fineTuning(.list).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<FineTuningJobObject>.self, with: request)
    }
    
@@ -133,7 +137,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> FineTuningJobObject
    {
-      let request = try OpenAIAPI.fineTuning(.retrieve(jobID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get)
+      let request = try OpenAIAPI.fineTuning(.retrieve(jobID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: FineTuningJobObject.self, with: request)
    }
    
@@ -141,7 +145,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> FineTuningJobObject
    {
-      let request = try OpenAIAPI.fineTuning(.cancel(jobID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .post)
+      let request = try OpenAIAPI.fineTuning(.cancel(jobID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .post, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: FineTuningJobObject.self, with: request)
    }
    
@@ -159,7 +163,7 @@ struct DefaultOpenAIService: OpenAIService {
       } else if let limit {
          queryItems = [.init(name: "limit", value: "\(limit)")]
       }
-      let request = try OpenAIAPI.fineTuning(.events(jobID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems)
+      let request = try OpenAIAPI.fineTuning(.events(jobID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<FineTuningJobEventObject>.self, with: request)
    }
    
@@ -168,7 +172,7 @@ struct DefaultOpenAIService: OpenAIService {
    func listFiles()
       async throws -> OpenAIResponse<FileObject>
    {
-      let request = try OpenAIAPI.file(.list).request(apiKey: apiKey, organizationID: organizationID, method: .get)
+      let request = try OpenAIAPI.file(.list).request(apiKey: apiKey, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<FileObject>.self, with: request)
    }
    
@@ -184,7 +188,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> DeletionStatus
    {
-      let request = try OpenAIAPI.file(.delete(fileID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .delete)
+      let request = try OpenAIAPI.file(.delete(fileID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .delete, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
    }
    
@@ -192,7 +196,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> FileObject
    {
-      let request = try OpenAIAPI.file(.retrieve(fileID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get)
+      let request = try OpenAIAPI.file(.retrieve(fileID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: FileObject.self, with: request)
    }
    
@@ -200,7 +204,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> [[String: Any]]
    {
-      let request = try OpenAIAPI.file(.retrieveFileContent(fileID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get)
+      let request = try OpenAIAPI.file(.retrieveFileContent(fileID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
       return try await fetchContentsOfFile(request: request)
    }
    
@@ -210,7 +214,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: ImageCreateParameters)
       async throws -> OpenAIResponse<ImageObject>
    {
-      let request = try OpenAIAPI.images(.generations).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters)
+      let request = try OpenAIAPI.images(.generations).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<ImageObject>.self,  with: request)
    }
    
@@ -235,7 +239,7 @@ struct DefaultOpenAIService: OpenAIService {
    func listModels()
       async throws -> OpenAIResponse<ModelObject>
    {
-      let request = try OpenAIAPI.model(.list).request(apiKey: apiKey, organizationID: organizationID, method: .get)
+      let request = try OpenAIAPI.model(.list).request(apiKey: apiKey, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<ModelObject>.self,  with: request)
    }
    
@@ -243,7 +247,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> ModelObject
    {
-      let request = try OpenAIAPI.model(.retrieve(modelID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get)
+      let request = try OpenAIAPI.model(.retrieve(modelID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: ModelObject.self,  with: request)
    }
    
@@ -251,7 +255,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> DeletionStatus
    {
-      let request = try OpenAIAPI.model(.deleteFineTuneModel(modelID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .delete)
+      let request = try OpenAIAPI.model(.deleteFineTuneModel(modelID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .delete, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self,  with: request)
    }
    
@@ -261,7 +265,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: ModerationParameter<String>)
       async throws -> ModerationObject
    {
-      let request = try OpenAIAPI.moderations.request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters)
+      let request = try OpenAIAPI.moderations.request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: ModerationObject.self, with: request)
    }
    
@@ -269,7 +273,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: ModerationParameter<[String]>)
       async throws -> ModerationObject
    {
-      let request = try OpenAIAPI.moderations.request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters)
+      let request = try OpenAIAPI.moderations.request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: ModerationObject.self, with: request)
    }
    
@@ -279,7 +283,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: AssistantParameters)
       async throws -> AssistantObject
    {
-      let request = try OpenAIAPI.assistant(.create).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.assistant(.create).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: AssistantObject.self, with: request)
    }
    
@@ -287,7 +291,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> AssistantObject
    {
-      let request = try OpenAIAPI.assistant(.retrieve(assistantID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.assistant(.retrieve(assistantID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: AssistantObject.self, with: request)
    }
    
@@ -296,7 +300,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: AssistantParameters)
       async throws -> AssistantObject
    {
-      let request = try OpenAIAPI.assistant(.modify(assistantID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.assistant(.modify(assistantID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: AssistantObject.self, with: request)
    }
    
@@ -304,7 +308,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> DeletionStatus
    {
-      let request = try OpenAIAPI.assistant(.delete(assistantID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.assistant(.delete(assistantID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
    }
    
@@ -328,7 +332,7 @@ struct DefaultOpenAIService: OpenAIService {
       if let before {
          queryItems.append(.init(name: "before", value: before))
       }
-      let request = try OpenAIAPI.assistant(.list).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.assistant(.list).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<AssistantObject>.self, with: request)
    }
    
@@ -338,14 +342,14 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: CreateThreadParameters)
       async throws -> ThreadObject
    {
-      let request = try OpenAIAPI.thread(.create).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.thread(.create).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: ThreadObject.self, with: request)
    }
    
    func retrieveThread(id: String)
       async throws -> ThreadObject
    {
-      let request = try OpenAIAPI.thread(.retrieve(threadID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.thread(.retrieve(threadID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: ThreadObject.self, with: request)
    }
    
@@ -354,7 +358,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: ModifyThreadParameters)
       async throws -> ThreadObject
    {
-      let request = try OpenAIAPI.thread(.modify(threadID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.thread(.modify(threadID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: ThreadObject.self, with: request)
    }
    
@@ -362,7 +366,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> DeletionStatus
    {
-      let request = try OpenAIAPI.thread(.delete(threadID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.thread(.delete(threadID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
    }
    
@@ -373,7 +377,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: MessageParameter)
       async throws -> MessageObject
    {
-      let request = try OpenAIAPI.message(.create(threadID: threadID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.message(.create(threadID: threadID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: MessageObject.self, with: request)
    }
    
@@ -382,7 +386,7 @@ struct DefaultOpenAIService: OpenAIService {
       messageID: String)
       async throws -> MessageObject
    {
-      let request = try OpenAIAPI.message(.retrieve(threadID: threadID, messageID: messageID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.message(.retrieve(threadID: threadID, messageID: messageID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: MessageObject.self, with: request)
    }
    
@@ -392,7 +396,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: ModifyMessageParameters)
       async throws -> MessageObject
    {
-      let request = try OpenAIAPI.message(.modify(threadID: threadID, messageID: messageID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.message(.modify(threadID: threadID, messageID: messageID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: MessageObject.self, with: request)
    }
    
@@ -401,7 +405,7 @@ struct DefaultOpenAIService: OpenAIService {
       messageID: String)
       async throws -> DeletionStatus
    {
-      let request = try OpenAIAPI.message(.delete(threadID: threadID, messageID: messageID)).request(apiKey: apiKey, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.message(.delete(threadID: threadID, messageID: messageID)).request(apiKey: apiKey, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
    }
    
@@ -430,7 +434,7 @@ struct DefaultOpenAIService: OpenAIService {
       if let runID {
          queryItems.append(.init(name: "run_id", value: runID))
       }
-      let request = try OpenAIAPI.message(.list(threadID: threadID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.message(.list(threadID: threadID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<MessageObject>.self, with: request)
    }
    
@@ -441,7 +445,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: RunParameter)
       async throws -> RunObject
    {
-      let request = try OpenAIAPI.run(.create(threadID: threadID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.run(.create(threadID: threadID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
    }
    
@@ -450,7 +454,7 @@ struct DefaultOpenAIService: OpenAIService {
       runID: String)
       async throws -> RunObject
    {
-      let request = try OpenAIAPI.run(.retrieve(threadID: threadID, runID: runID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.run(.retrieve(threadID: threadID, runID: runID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
    }
    
@@ -460,7 +464,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: ModifyRunParameters)
       async throws -> RunObject
    {
-      let request = try OpenAIAPI.run(.modify(threadID: threadID, runID: runID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.run(.modify(threadID: threadID, runID: runID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
    }
    
@@ -485,7 +489,7 @@ struct DefaultOpenAIService: OpenAIService {
       if let before {
          queryItems.append(.init(name: "before", value: before))
       }
-      let request = try OpenAIAPI.run(.list(threadID: threadID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.run(.list(threadID: threadID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<RunObject>.self, with: request)
    }
    
@@ -494,7 +498,7 @@ struct DefaultOpenAIService: OpenAIService {
       runID: String)
       async throws -> RunObject
    {
-      let request = try OpenAIAPI.run(.cancel(threadID: threadID, runID: runID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.run(.cancel(threadID: threadID, runID: runID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
    }
    
@@ -504,7 +508,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: RunToolsOutputParameter)
       async throws -> RunObject
    {
-      let request = try OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
    }
    
@@ -512,7 +516,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: CreateThreadAndRunParameter)
       async throws -> RunObject
    {
-      let request = try OpenAIAPI.run(.createThreadAndRun).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.run(.createThreadAndRun).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
    }
    
@@ -524,7 +528,7 @@ struct DefaultOpenAIService: OpenAIService {
       stepID: String)
       async throws -> RunStepObject
    {
-      let request = try OpenAIAPI.runStep(.retrieve(threadID: threadID, runID: runID, stepID: stepID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.runStep(.retrieve(threadID: threadID, runID: runID, stepID: stepID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: RunStepObject.self, with: request)
    }
    
@@ -550,7 +554,7 @@ struct DefaultOpenAIService: OpenAIService {
       if let before {
          queryItems.append(.init(name: "before", value: before))
       }
-      let request = try OpenAIAPI.runStep(.list(threadID: threadID, runID: runID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.runStep(.list(threadID: threadID, runID: runID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<RunStepObject>.self, with: request)
    }
    
@@ -561,7 +565,7 @@ struct DefaultOpenAIService: OpenAIService {
    {
       var runParameters = parameters
       runParameters.stream = true
-      let request = try OpenAIAPI.run(.create(threadID: threadID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: runParameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.run(.create(threadID: threadID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: runParameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetchAssistantStreamEvents(with: request, debugEnabled: debugEnabled)
    }
    
@@ -570,7 +574,7 @@ struct DefaultOpenAIService: OpenAIService {
    async throws -> AsyncThrowingStream<AssistantStreamEvent, Error> {
       var runParameters = parameters
       runParameters.stream = true
-      let request = try OpenAIAPI.run(.createThreadAndRun).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.run(.createThreadAndRun).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetchAssistantStreamEvents(with: request, debugEnabled: debugEnabled)
    }
    
@@ -582,7 +586,7 @@ struct DefaultOpenAIService: OpenAIService {
    {
       var runToolsOutputParameter = parameters
       runToolsOutputParameter.stream = true
-      let request = try OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: runToolsOutputParameter, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: runToolsOutputParameter, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetchAssistantStreamEvents(with: request, debugEnabled: debugEnabled)
    }
    
@@ -592,7 +596,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: BatchParameter)
       async throws -> BatchObject
    {
-      let request = try OpenAIAPI.batch(.create).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters)
+      let request = try OpenAIAPI.batch(.create).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: BatchObject.self, with: request)
    }
    
@@ -600,7 +604,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> BatchObject
    {
-      let request = try OpenAIAPI.batch(.retrieve(batchID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get)
+      let request = try OpenAIAPI.batch(.retrieve(batchID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: BatchObject.self, with: request)
    }
    
@@ -608,7 +612,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> BatchObject
    {
-      let request = try OpenAIAPI.batch(.cancel(batchID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .post)
+      let request = try OpenAIAPI.batch(.cancel(batchID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .post, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: BatchObject.self, with: request)
    }
    
@@ -624,7 +628,7 @@ struct DefaultOpenAIService: OpenAIService {
       if let after {
          queryItems.append(.init(name: "after", value: after))
       }
-      let request = try OpenAIAPI.batch(.list).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems)
+      let request = try OpenAIAPI.batch(.list).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<BatchObject>.self, with: request)
    }
    
@@ -634,7 +638,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: VectorStoreParameter)
       async throws -> VectorStoreObject
    {
-      let request = try OpenAIAPI.vectorStore(.create).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.vectorStore(.create).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreObject.self, with: request)
    }
    
@@ -658,7 +662,7 @@ struct DefaultOpenAIService: OpenAIService {
       if let before {
          queryItems.append(.init(name: "before", value: before))
       }
-      let request = try OpenAIAPI.vectorStore(.list).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.vectorStore(.list).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<VectorStoreObject>.self, with: request)
    }
    
@@ -666,7 +670,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String) async throws
       -> VectorStoreObject
    {
-      let request = try OpenAIAPI.vectorStore(.retrieve(vectorStoreID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.vectorStore(.retrieve(vectorStoreID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreObject.self, with: request)
    }
    
@@ -675,7 +679,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> VectorStoreObject
    {
-      let request = try OpenAIAPI.vectorStore(.modify(vectorStoreID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.vectorStore(.modify(vectorStoreID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreObject.self, with: request)
    }
    
@@ -683,7 +687,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> DeletionStatus
    {
-      let request = try OpenAIAPI.vectorStore(.modify(vectorStoreID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.vectorStore(.modify(vectorStoreID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
    }
    
@@ -692,9 +696,9 @@ struct DefaultOpenAIService: OpenAIService {
    func createVectorStoreFile(
       vectorStoreID: String,
       parameters: VectorStoreFileParameter)
-   async throws -> VectorStoreFileObject 
+   async throws -> VectorStoreFileObject
    {
-      let request = try OpenAIAPI.vectorStoreFile(.create(vectorStoreID: vectorStoreID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.vectorStoreFile(.create(vectorStoreID: vectorStoreID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreFileObject.self, with: request)
    }
    
@@ -723,7 +727,7 @@ struct DefaultOpenAIService: OpenAIService {
       if let filter {
          queryItems.append(.init(name: "filter", value: filter))
       }
-      let request = try OpenAIAPI.vectorStoreFile(.list(vectorStoreID: vectorStoreID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.vectorStoreFile(.list(vectorStoreID: vectorStoreID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<VectorStoreFileObject>.self, with: request)
    }
    
@@ -732,7 +736,7 @@ struct DefaultOpenAIService: OpenAIService {
       fileID: String)
       async throws -> VectorStoreFileObject
    {
-      let request = try OpenAIAPI.vectorStoreFile(.retrieve(vectorStoreID: vectorStoreID, fileID: fileID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.vectorStoreFile(.retrieve(vectorStoreID: vectorStoreID, fileID: fileID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreFileObject.self, with: request)
    }
    
@@ -741,7 +745,7 @@ struct DefaultOpenAIService: OpenAIService {
       fileID: String)
       async throws -> DeletionStatus
    {
-      let request = try OpenAIAPI.vectorStoreFile(.delete(vectorStoreID: vectorStoreID, fileID: fileID)).request(apiKey: apiKey, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.vectorStoreFile(.delete(vectorStoreID: vectorStoreID, fileID: fileID)).request(apiKey: apiKey, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
    }
    
@@ -752,7 +756,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: VectorStoreFileBatchParameter)
       async throws -> VectorStoreFileBatchObject
    {
-      let request = try OpenAIAPI.vectorStoreFileBatch(.create(vectorStoreID: vectorStoreID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.vectorStoreFileBatch(.create(vectorStoreID: vectorStoreID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreFileBatchObject.self, with: request)
    }
    
@@ -761,7 +765,7 @@ struct DefaultOpenAIService: OpenAIService {
       batchID: String)
       async throws -> VectorStoreFileBatchObject
    {
-      let request = try OpenAIAPI.vectorStoreFileBatch(.retrieve(vectorStoreID: vectorStoreID, batchID: batchID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.vectorStoreFileBatch(.retrieve(vectorStoreID: vectorStoreID, batchID: batchID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreFileBatchObject.self, with: request)
    }
    
@@ -770,7 +774,7 @@ struct DefaultOpenAIService: OpenAIService {
       batchID: String)
       async throws -> VectorStoreFileBatchObject
    {
-      let request = try OpenAIAPI.vectorStoreFileBatch(.cancel(vectorStoreID: vectorStoreID, batchID: batchID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.vectorStoreFileBatch(.cancel(vectorStoreID: vectorStoreID, batchID: batchID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreFileBatchObject.self, with: request)
    }
    
@@ -800,8 +804,9 @@ struct DefaultOpenAIService: OpenAIService {
       if let filter {
          queryItems.append(.init(name: "filter", value: filter))
       }
-      let request = try OpenAIAPI.vectorStoreFileBatch(.list(vectorStoreID: vectorStoreID, batchID: batchID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2)
+      let request = try OpenAIAPI.vectorStoreFileBatch(.list(vectorStoreID: vectorStoreID, batchID: batchID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<VectorStoreFileObject>.self, with: request)
    }
 }
+
 

--- a/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
+++ b/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
@@ -133,6 +133,7 @@ public class OpenAIServiceFactory {
    ///   - baseURL: The local host URL.  e.g "https://api.groq.com" or "https://generativelanguage.googleapis.com"
    ///   - proxyPath: The proxy path e.g `openai`
    ///   - overrideVersion: The API version. defaults to `V1`
+   ///   - extraHeaders: Additional headers needed for the request. Do not provide API key in these headers.
    ///   - debugEnabled: If `true` service prints event on DEBUG builds, default to `false`.
    ///
    /// - Returns: A fully configured object conforming to `OpenAIService`.
@@ -141,6 +142,7 @@ public class OpenAIServiceFactory {
       overrideBaseURL: String,
       proxyPath: String? = nil,
       overrideVersion: String? = nil,
+      extraHeaders: [String: String]? = nil,
       debugEnabled: Bool = false)
       -> OpenAIService
    {
@@ -149,6 +151,7 @@ public class OpenAIServiceFactory {
          baseURL: overrideBaseURL,
          proxyPath: proxyPath,
          overrideVersion: overrideVersion,
+         extraHeaders: extraHeaders,
          debugEnabled: debugEnabled)
    }
 }


### PR DESCRIPTION
Consumers now can pass additional parameters in to the request. e.g Open Router:

```swift
let service = OpenAIServiceFactory.service(
              apikey:  "${OPENROUTER_API_KEY}",  
             baseURL: "https://openrouter.ai",
             proxyPath: "api"
             headers: ["HTTP-Referer":  "${YOUR_SITE_URL}",  "X-Title":  "${YOUR_SITE_NAME}")
```