### PR TITLE
Removing Static properties from OpenAI API

### DIFF
--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/LocalChatDemo/LocalChatDemoView.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/LocalChatDemo/LocalChatDemoView.swift
@@ -99,8 +99,8 @@ struct LocalChatDemoView: View {
                   messages: [.init(
                   role: .user,
                   content: content)],
-                  // Make sure you run `ollama pull llama3` in your terminal to download this model.
-                  model: .custom("llama3"))
+                  // Make sure you run `ollama pull llama3.1` in your terminal to download this model.
+                  model: .custom("llama3.1"))
                switch selectedSegment {
                case .chatCompletion:
                   try await chatProvider.startChat(parameters: parameters)

--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/LocalHostEntryView.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/LocalHostEntryView.swift
@@ -19,7 +19,7 @@ struct LocalHostEntryView: View {
             TextField("Enter URL", text: $url)
             .padding()
             .textFieldStyle(.roundedBorder)
-            NavigationLink(destination: OptionsListView(openAIService: OpenAIServiceFactory.service(baseURL: url), options: [.localChat])) {
+            NavigationLink(destination: OptionsListView(openAIService: OpenAIServiceFactory.service(baseURL: url, debugEnabled: true), options: [.localChat])) {
                Text("Continue")
                   .padding()
                   .padding(.horizontal, 48)

--- a/Sources/OpenAI/AIProxy/AIProxyService.swift
+++ b/Sources/OpenAI/AIProxy/AIProxyService.swift
@@ -30,8 +30,20 @@ struct AIProxyService: OpenAIService {
 
    private static let assistantsBetaV2 = "assistants=v2"
 
-   /// Your service URL is also provided during the integration process. If you integrated before
-   /// July 22nd, 2024, you can continue to leave `serviceURL` blank.
+   /// Initializes an instance of the OpenAI service with the required configurations.
+   ///
+   /// - Parameters:
+   ///   - partialKey: Your partial key provided during the integration process at `dashboard.aiproxy.pro`.
+   ///                 Refer to the [integration guide](https://www.aiproxy.pro/docs/integration-guide.html)
+   ///                 for details on acquiring your partial key. This is required.
+   ///   - serviceURL: Your service URL, also provided during the integration process. If you integrated before
+   ///                 July 22nd, 2024, you can leave this parameter blank, and it will default to
+   ///                 `"https://api.aiproxy.pro"`. This is optional.
+   ///   - clientID: An optional client ID to annotate requests in the AIProxy developer dashboard.
+   ///               If left blank, AIProxy generates client IDs for you. Most users can safely leave this blank.
+   ///   - organizationID: An optional OpenAI organization ID. Refer to the [organization documentation](https://platform.openai.com/docs/api-reference/organization-optional)
+   ///                     for details on its usage. Defaults to `nil`.
+   ///   - debugEnabled: A flag to enable printing request events during DEBUG builds. Set this to `true` for debugging.
    init(
       partialKey: String,
       serviceURL: String? = nil,

--- a/Sources/OpenAI/AIProxy/Endpoint+AIProxy.swift
+++ b/Sources/OpenAI/AIProxy/Endpoint+AIProxy.swift
@@ -35,11 +35,12 @@ private let deviceCheckWarning = """
 extension Endpoint {
 
     private func urlComponents(
-      serviceURL: String?,
+      serviceURL: String,
+      path: String,
       queryItems: [URLQueryItem])
        -> URLComponents
     {
-       var components = URLComponents(string: serviceURL ?? "https://api.aiproxy.pro")!
+       var components = URLComponents(string: serviceURL)!
        components.path = components.path.appending(path)
        if !queryItems.isEmpty {
           components.queryItems = queryItems
@@ -49,16 +50,17 @@ extension Endpoint {
 
    func request(
       aiproxyPartialKey: String,
-      serviceURL: String?,
       clientID: String?,
       organizationID: String?,
+      openAIEnvironment: OpenAIEnvironment,
       method: HTTPMethod,
       params: Encodable? = nil,
       queryItems: [URLQueryItem] = [],
       betaHeaderField: String? = nil)
       async throws -> URLRequest
    {
-      var request = URLRequest(url: urlComponents(serviceURL: serviceURL, queryItems: queryItems).url!)
+      let finalPath = path(in: openAIEnvironment)
+      var request = URLRequest(url: urlComponents(serviceURL: openAIEnvironment.baseURL, path: finalPath, queryItems: queryItems).url!)
       request.addValue("application/json", forHTTPHeaderField: "Content-Type")
       request.addValue(aiproxyPartialKey, forHTTPHeaderField: "aiproxy-partial-key")
       if let organizationID {
@@ -87,7 +89,7 @@ extension Endpoint {
 
    func multiPartRequest(
       aiproxyPartialKey: String,
-      serviceURL: String?,
+      openAIEnvironment: OpenAIEnvironment,
       clientID: String?,
       organizationID: String?,
       method: HTTPMethod,
@@ -96,7 +98,8 @@ extension Endpoint {
    )
       async throws -> URLRequest
    {
-      var request = URLRequest(url: urlComponents(serviceURL: serviceURL, queryItems: queryItems).url!)
+      let finalPath = path(in: openAIEnvironment)
+      var request = URLRequest(url: urlComponents(serviceURL: openAIEnvironment.baseURL, path: finalPath, queryItems: queryItems).url!)
       request.httpMethod = method.rawValue
       request.addValue(aiproxyPartialKey, forHTTPHeaderField: "aiproxy-partial-key")
       if let organizationID {

--- a/Sources/OpenAI/Azure/AzureOpenAIAPI.swift
+++ b/Sources/OpenAI/Azure/AzureOpenAIAPI.swift
@@ -10,9 +10,7 @@ import Foundation
 // MARK: - AzureOpenAIAPI
 
 enum AzureOpenAIAPI {
-   
-   static var azureOpenAIResource: String = ""
-   
+      
    /// https://learn.microsoft.com/en-us/azure/ai-services/openai/assistants-reference?tabs=python
    /// https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/assistant
    case assistant(AssistantCategory)
@@ -90,11 +88,7 @@ enum AzureOpenAIAPI {
 
 extension AzureOpenAIAPI: Endpoint {
    
-   var base: String {
-      "https://\(Self.azureOpenAIResource)/openai.azure.com"
-   }
-   
-   var path: String {
+   func path(in env: OpenAIEnvironment) -> String {
       switch self {
       case .chat(let deploymentID): return "/openai/deployments/\(deploymentID)/chat/completions"
       case .assistant(let category):

--- a/Sources/OpenAI/Azure/DefaultOpenAIAzureService.swift
+++ b/Sources/OpenAI/Azure/DefaultOpenAIAzureService.swift
@@ -17,7 +17,11 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    {
       session = URLSession(configuration: urlSessionConfiguration)
       self.decoder = decoder
-      AzureOpenAIAPI.azureOpenAIResource = azureConfiguration.resourceName
+      self.openAIEnvironment = OpenAIEnvironment(
+         baseURL: "https://\(azureConfiguration.resourceName)/openai.azure.com",
+         proxyPath: nil,
+         version: nil
+     )
       apiKey = azureConfiguration.openAIAPIKey
       extraHeaders = azureConfiguration.extraHeaders
       initialQueryItems = [.init(name: "api-version", value: azureConfiguration.apiVersion)]
@@ -26,10 +30,13 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    
    public let session: URLSession
    public let decoder: JSONDecoder
+   public let openAIEnvironment: OpenAIEnvironment
+
    private let apiKey: Authorization
    private let initialQueryItems: [URLQueryItem]
    /// Set this flag to TRUE if you need to print request events in DEBUG builds.
    private let debugEnabled: Bool
+   
    
    // Assistants API
    private let extraHeaders: [String: String]?
@@ -52,6 +59,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
       chatParameters.stream = false
       let request = try AzureOpenAIAPI.chat(deploymentID: parameters.model).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post,
          params: chatParameters,
@@ -64,6 +72,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
       chatParameters.stream = true
       let request = try AzureOpenAIAPI.chat(deploymentID: parameters.model).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post,
          params: chatParameters,
@@ -151,6 +160,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func createAssistant(parameters: AssistantParameters) async throws -> AssistantObject {
       let request = try AzureOpenAIAPI.assistant(.create).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post,
          params: parameters,
@@ -164,6 +174,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func retrieveAssistant(id: String) async throws -> AssistantObject {
       let request = try AzureOpenAIAPI.assistant(.retrieve(assistantID: id)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .get,
          queryItems: initialQueryItems,
@@ -176,6 +187,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func modifyAssistant(id: String, parameters: AssistantParameters) async throws -> AssistantObject {
       let request = try AzureOpenAIAPI.assistant(.modify(assistantID: id)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post,
          params: parameters,
@@ -189,6 +201,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func deleteAssistant(id: String) async throws -> DeletionStatus {
       let request = try AzureOpenAIAPI.assistant(.delete(assistantID: id)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .delete,
          queryItems: initialQueryItems,
@@ -214,6 +227,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
       }
       let request = try AzureOpenAIAPI.assistant(.list).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .get,
          queryItems: queryItems,
@@ -226,6 +240,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func createThread(parameters: CreateThreadParameters) async throws -> ThreadObject {
       let request = try AzureOpenAIAPI.thread(.create).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post, 
          params: parameters,
@@ -238,6 +253,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func retrieveThread(id: String) async throws -> ThreadObject {
       let request = try AzureOpenAIAPI.thread(.retrieve(threadID: id)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .get,
          queryItems: initialQueryItems,
@@ -249,6 +265,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func modifyThread(id: String, parameters: ModifyThreadParameters) async throws -> ThreadObject {
       let request = try AzureOpenAIAPI.thread(.modify(threadID: id)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post,
          params: parameters,
@@ -261,6 +278,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func deleteThread(id: String) async throws -> DeletionStatus {
       let request = try AzureOpenAIAPI.thread(.delete(threadID: id)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .delete,
          queryItems: initialQueryItems,
@@ -272,6 +290,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func createMessage(threadID: String, parameters: MessageParameter) async throws -> MessageObject {
       let request = try AzureOpenAIAPI.message(.create(threadID: threadID)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post,
          params: parameters,
@@ -284,6 +303,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func retrieveMessage(threadID: String, messageID: String) async throws -> MessageObject {
       let request = try AzureOpenAIAPI.message(.retrieve(threadID: threadID, messageID: messageID)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .get,
          queryItems: initialQueryItems,
@@ -295,6 +315,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func modifyMessage(threadID: String, messageID: String, parameters: ModifyMessageParameters) async throws -> MessageObject {
       let request = try AzureOpenAIAPI.message(.modify(threadID: threadID, messageID: messageID)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post,
          params: parameters,
@@ -311,6 +332,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    {
       let request = try AzureOpenAIAPI.message(.delete(threadID: threadID, messageID: messageID)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .delete,
          queryItems: initialQueryItems,
@@ -338,6 +360,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
       }
       let request = try AzureOpenAIAPI.message(.list(threadID: threadID)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .get,
          queryItems: queryItems,
@@ -349,6 +372,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func createRun(threadID: String, parameters: RunParameter) async throws -> RunObject {
       let request = try AzureOpenAIAPI.run(.create(threadID: threadID)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post,
          params: parameters,
@@ -361,6 +385,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func retrieveRun(threadID: String, runID: String) async throws -> RunObject {
       let request = try AzureOpenAIAPI.run(.retrieve(threadID: threadID, runID: runID)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post,
          queryItems: initialQueryItems,
@@ -372,6 +397,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func modifyRun(threadID: String, runID: String, parameters: ModifyRunParameters) async throws -> RunObject {
       let request = try AzureOpenAIAPI.run(.modify(threadID: threadID, runID: runID)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post,
          params: parameters,
@@ -397,6 +423,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
       }
       let request = try AzureOpenAIAPI.run(.list(threadID: threadID)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post,
          queryItems: queryItems,
@@ -408,6 +435,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func cancelRun(threadID: String, runID: String) async throws -> RunObject {
       let request = try AzureOpenAIAPI.run(.cancel(threadID: threadID, runID: runID)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post,
          queryItems: initialQueryItems,
@@ -419,6 +447,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func submitToolOutputsToRun(threadID: String, runID: String, parameters: RunToolsOutputParameter) async throws -> RunObject {
       let request = try AzureOpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post,
          params: parameters,
@@ -431,6 +460,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func createThreadAndRun(parameters: CreateThreadAndRunParameter) async throws -> RunObject {
       let request = try AzureOpenAIAPI.run(.createThreadAndRun).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post,
          params: parameters,
@@ -443,6 +473,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func retrieveRunstep(threadID: String, runID: String, stepID: String) async throws -> RunStepObject {
       let request = try OpenAIAPI.runStep(.retrieve(threadID: threadID, runID: runID, stepID: stepID)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .get,
          queryItems: initialQueryItems,
@@ -467,6 +498,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
       }
       let request = try AzureOpenAIAPI.runStep(.list(threadID: threadID, runID: runID)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .get,
          queryItems: queryItems,
@@ -483,6 +515,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
       runParameters.stream = true
       let request = try AzureOpenAIAPI.run(.createThreadAndRun).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post,
          params: runParameters,
@@ -501,6 +534,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
       runParameters.stream = true
       let request = try AzureOpenAIAPI.run(.create(threadID: threadID)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post,
          params: runParameters,
@@ -520,6 +554,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
       runToolsOutputParameter.stream = true
       let request = try AzureOpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post,
          params: runToolsOutputParameter,
@@ -567,6 +602,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    {
       let request = try AzureOpenAIAPI.vectorStore(.create).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post,
          params: parameters, 
@@ -598,6 +634,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
       }
       let request = try AzureOpenAIAPI.vectorStore(.list).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .get,
          queryItems: queryItems,
@@ -612,6 +649,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    {
       let request = try AzureOpenAIAPI.vectorStore(.retrieve(vectorStoreID: id)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .get,
          queryItems: initialQueryItems,
@@ -627,6 +665,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    {
       let request = try AzureOpenAIAPI.vectorStore(.modify(vectorStoreID: id)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post,
          params: parameters,
@@ -642,6 +681,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    {
       let request = try AzureOpenAIAPI.vectorStore(.delete(vectorStoreID: id)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .delete,
          queryItems: initialQueryItems,
@@ -655,6 +695,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func createVectorStoreFile(vectorStoreID: String, parameters: VectorStoreFileParameter) async throws -> VectorStoreFileObject {
       let request = try AzureOpenAIAPI.vectorStoreFile(.create(vectorStoreID: vectorStoreID)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .post,
          params: parameters,
@@ -683,6 +724,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
       }
       let request = try AzureOpenAIAPI.vectorStoreFile(.list(vectorStoreID: vectorStoreID)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .get,
          queryItems: queryItems,
@@ -694,6 +736,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func retrieveVectorStoreFile(vectorStoreID: String, fileID: String) async throws -> VectorStoreFileObject {
       let request = try AzureOpenAIAPI.vectorStoreFile(.retrieve(vectorStoreID: vectorStoreID, fileID: fileID)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .get,
          queryItems: initialQueryItems,
@@ -705,6 +748,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
    public func deleteVectorStoreFile(vectorStoreID: String, fileID: String) async throws -> DeletionStatus {
       let request = try AzureOpenAIAPI.vectorStoreFile(.delete(vectorStoreID: vectorStoreID, fileID: fileID)).request(
          apiKey: apiKey,
+         openAIEnvironment: openAIEnvironment,
          organizationID: nil,
          method: .delete,
          queryItems: initialQueryItems,

--- a/Sources/OpenAI/LocalModelService/LocalModelService.swift
+++ b/Sources/OpenAI/LocalModelService/LocalModelService.swift
@@ -30,7 +30,7 @@ struct LocalModelService: OpenAIService {
       self.session = URLSession(configuration: configuration)
       self.decoder = decoder
       self.apiKey = apiKey
-      self.openAIEnvironment = OpenAIEnvironment(baseURL: baseURL, proxyPath: proxyPath, version: overrideVersion)
+      self.openAIEnvironment = OpenAIEnvironment(baseURL: baseURL, proxyPath: proxyPath, version: overrideVersion ?? "v1")
       self.debugEnabled = debugEnabled
    }
    

--- a/Sources/OpenAI/LocalModelService/LocalModelService.swift
+++ b/Sources/OpenAI/LocalModelService/LocalModelService.swift
@@ -11,6 +11,8 @@ struct LocalModelService: OpenAIService {
    
    let session: URLSession
    let decoder: JSONDecoder
+   let openAIEnvironment: OpenAIEnvironment
+
    /// [authentication](https://platform.openai.com/docs/api-reference/authentication)
    private let apiKey: Authorization
    /// Set this flag to TRUE if you need to print request events in DEBUG builds.
@@ -19,6 +21,8 @@ struct LocalModelService: OpenAIService {
    public init(
       apiKey: Authorization = .apiKey(""),
       baseURL: String,
+      proxyPath: String? = nil,
+      overrideVersion: String? = nil,
       configuration: URLSessionConfiguration = .default,
       decoder: JSONDecoder = .init(),
       debugEnabled: Bool)
@@ -26,7 +30,7 @@ struct LocalModelService: OpenAIService {
       self.session = URLSession(configuration: configuration)
       self.decoder = decoder
       self.apiKey = apiKey
-      LocalModelAPI.overrideBaseURL = baseURL
+      self.openAIEnvironment = OpenAIEnvironment(baseURL: baseURL, proxyPath: proxyPath, version: overrideVersion)
       self.debugEnabled = debugEnabled
    }
    
@@ -48,7 +52,7 @@ struct LocalModelService: OpenAIService {
    {
       var chatParameters = parameters
       chatParameters.stream = false
-      let request = try LocalModelAPI.chat.request(apiKey: apiKey, organizationID: nil, method: .post, params: chatParameters)
+      let request = try LocalModelAPI.chat.request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: nil, method: .post, params: chatParameters)
       return try await fetch(debugEnabled: debugEnabled, type: ChatCompletionObject.self, with: request)
    }
    
@@ -59,7 +63,7 @@ struct LocalModelService: OpenAIService {
       var chatParameters = parameters
       chatParameters.stream = true
       chatParameters.streamOptions = .init(includeUsage: true)
-      let request = try LocalModelAPI.chat.request(apiKey: apiKey, organizationID: nil, method: .post, params: chatParameters)
+      let request = try LocalModelAPI.chat.request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: nil, method: .post, params: chatParameters)
       return try await fetchStream(debugEnabled: debugEnabled, type: ChatCompletionChunkObject.self, with: request)
    }
    

--- a/Sources/OpenAI/Private/Networking/Endpoint.swift
+++ b/Sources/OpenAI/Private/Networking/Endpoint.swift
@@ -18,9 +18,9 @@ enum HTTPMethod: String {
 // MARK: Endpoint
 
 protocol Endpoint {
-   
-   var base: String { get }
-   var path: String { get }
+   func path(
+      in openAIEnvironment: OpenAIEnvironment)
+      -> String
 }
 
 // MARK: Endpoint+Requests
@@ -28,6 +28,8 @@ protocol Endpoint {
 extension Endpoint {
 
    private func urlComponents(
+      base: String,
+      path: String,
       queryItems: [URLQueryItem])
       -> URLComponents
    {
@@ -41,6 +43,7 @@ extension Endpoint {
    
    func request(
       apiKey: Authorization,
+      openAIEnvironment: OpenAIEnvironment,
       organizationID: String?,
       method: HTTPMethod,
       params: Encodable? = nil,
@@ -49,7 +52,8 @@ extension Endpoint {
       extraHeaders: [String: String]? = nil)
       throws -> URLRequest
    {
-      var request = URLRequest(url: urlComponents(queryItems: queryItems).url!)
+      let finalPath = path(in: openAIEnvironment)
+      var request = URLRequest(url: urlComponents(base: openAIEnvironment.baseURL, path: finalPath, queryItems: queryItems).url!)
       request.addValue("application/json", forHTTPHeaderField: "Content-Type")
       request.addValue(apiKey.value, forHTTPHeaderField: apiKey.headerField)
       if let organizationID {
@@ -72,13 +76,15 @@ extension Endpoint {
    
    func multiPartRequest(
       apiKey: Authorization,
+      openAIEnvironment: OpenAIEnvironment,
       organizationID: String?,
       method: HTTPMethod,
       params: MultipartFormDataParameters,
       queryItems: [URLQueryItem] = [])
       throws -> URLRequest
    {
-      var request = URLRequest(url: urlComponents(queryItems: queryItems).url!)
+      let finalPath = path(in: openAIEnvironment)
+      var request = URLRequest(url: urlComponents(base: openAIEnvironment.baseURL, path: finalPath, queryItems: queryItems).url!)
       request.httpMethod = method.rawValue
       let boundary = UUID().uuidString
       request.addValue(apiKey.value, forHTTPHeaderField: apiKey.headerField)

--- a/Sources/OpenAI/Private/Networking/OpenAIAPI.swift
+++ b/Sources/OpenAI/Private/Networking/OpenAIAPI.swift
@@ -11,10 +11,6 @@ import Foundation
 
 enum OpenAIAPI {
    
-   static var overrideBaseURL: String? = nil
-   static var proxyPath: String? = nil
-   static var overrideVersion: String? = nil
-
    case assistant(AssistantCategory) // https://platform.openai.com/docs/api-reference/assistants
    case audio(AudioCategory) // https://platform.openai.com/docs/api-reference/audio
    case chat /// https://platform.openai.com/docs/api-reference/chat
@@ -140,98 +136,106 @@ enum OpenAIAPI {
 
 extension OpenAIAPI: Endpoint {
    
-   var base: String {
-      Self.overrideBaseURL ?? "https://api.openai.com"
-   }
-   
-   var path: String {
-      guard
-         let proxyPath = Self.proxyPath
-      else {
-         return openAIPath
+   /// Builds the final path that includes:
+   /// 
+   ///   - optional proxy path (e.g. "/my-proxy")
+   ///   - version if non-nil (e.g. "/v1")
+   ///   - then the specific endpoint path (e.g. "/assistants")
+   func path(in openAIEnvironment: OpenAIEnvironment) -> String {
+      // 1) Potentially prepend proxy path if `proxyPath` is non-empty
+      let proxyPart: String
+      if let envProxyPart = openAIEnvironment.proxyPath, !envProxyPart.isEmpty {
+         proxyPart = "/\(envProxyPart)"
+      } else {
+         proxyPart = ""
       }
-      return "/\(proxyPath)\(openAIPath)"
+      let mainPart = openAIPath(in: openAIEnvironment)
+      
+      return proxyPart + mainPart // e.g. "/my-proxy/v1/assistants"
    }
-   
-   var version: String {
-      Self.overrideVersion ?? "v1"
-   }
-   
-   var openAIPath: String {
+
+   func openAIPath(in openAIEnvironment: OpenAIEnvironment) -> String {
+      let version: String
+      if let envOverrideVersion = openAIEnvironment.version, !envOverrideVersion.isEmpty {
+         version = "/\(envOverrideVersion)"
+      } else {
+         version = ""
+      }
+      
       switch self {
       case .assistant(let category):
          switch category {
-         case .create, .list: return "/\(version)/assistants"
-         case .retrieve(let assistantID), .modify(let assistantID), .delete(let assistantID): return "/\(version)/assistants/\(assistantID)"
+         case .create, .list: return "\(version)/assistants"
+         case .retrieve(let assistantID), .modify(let assistantID), .delete(let assistantID): return "\(version)/assistants/\(assistantID)"
          }
-      case .audio(let category): return "/\(version)/audio/\(category.rawValue)"
+      case .audio(let category): return "\(version)/audio/\(category.rawValue)"
       case .batch(let category):
          switch category {
          case .create, .list: return "\(version)/batches"
          case .retrieve(let batchID): return "\(version)/batches/\(batchID)"
          case .cancel(let batchID): return "\(version)/batches/\(batchID)/cancel"
          }
-      case .chat: return "/\(version)/chat/completions"
-      case .embeddings: return "/\(version)/embeddings"
+      case .chat: return "\(version)/chat/completions"
+      case .embeddings: return "\(version)/embeddings"
       case .file(let category):
          switch category {
-         case .list, .upload: return "/\(version)/files"
-         case .delete(let fileID), .retrieve(let fileID): return "/\(version)/files/\(fileID)"
-         case .retrieveFileContent(let fileID): return "/\(version)/files/\(fileID)/content"
+         case .list, .upload: return "\(version)/files"
+         case .delete(let fileID), .retrieve(let fileID): return "\(version)/files/\(fileID)"
+         case .retrieveFileContent(let fileID): return "\(version)/files/\(fileID)/content"
          }
       case .fineTuning(let category):
          switch category {
-         case .create, .list: return "/\(version)/fine_tuning/jobs"
-         case .retrieve(let jobID): return "/\(version)/fine_tuning/jobs/\(jobID)"
-         case .cancel(let jobID): return "/\(version)/fine_tuning/jobs/\(jobID)/cancel"
-         case .events(let jobID): return "/\(version)/fine_tuning/jobs/\(jobID)/events"
+         case .create, .list: return "\(version)/fine_tuning/jobs"
+         case .retrieve(let jobID): return "\(version)/fine_tuning/jobs/\(jobID)"
+         case .cancel(let jobID): return "\(version)/fine_tuning/jobs/\(jobID)/cancel"
+         case .events(let jobID): return "\(version)/fine_tuning/jobs/\(jobID)/events"
          }
-      case .images(let category): return "/\(version)/images/\(category.rawValue)"
+      case .images(let category): return "\(version)/images/\(category.rawValue)"
       case .message(let category):
          switch category {
-         case .create(let threadID), .list(let threadID): return "/\(version)/threads/\(threadID)/messages"
-         case .retrieve(let threadID, let messageID), .modify(let threadID, let messageID), .delete(let threadID, let messageID): return "/\(version)/threads/\(threadID)/messages/\(messageID)"
+         case .create(let threadID), .list(let threadID): return "\(version)/threads/\(threadID)/messages"
+         case .retrieve(let threadID, let messageID), .modify(let threadID, let messageID), .delete(let threadID, let messageID): return "\(version)/threads/\(threadID)/messages/\(messageID)"
          }
       case .model(let category):
          switch category {
-         case .list: return "/\(version)/models"
-         case .retrieve(let modelID), .deleteFineTuneModel(let modelID): return "/\(version)/models/\(modelID)"
+         case .list: return "\(version)/models"
+         case .retrieve(let modelID), .deleteFineTuneModel(let modelID): return "\(version)/models/\(modelID)"
          }
-      case .moderations: return "/\(version)/moderations"
+      case .moderations: return "\(version)/moderations"
       case .run(let category):
          switch category {
-         case .create(let threadID), .list(let threadID): return "/\(version)/threads/\(threadID)/runs"
-         case .retrieve(let threadID, let runID), .modify(let threadID, let runID): return "/\(version)/threads/\(threadID)/runs/\(runID)"
-         case .cancel(let threadID, let runID): return "/\(version)/threads/\(threadID)/runs/\(runID)/cancel"
-         case .submitToolOutput(let threadID, let runID): return "/\(version)/threads/\(threadID)/runs/\(runID)/submit_tool_outputs"
-         case .createThreadAndRun: return "/\(version)/threads/runs"
+         case .create(let threadID), .list(let threadID): return "\(version)/threads/\(threadID)/runs"
+         case .retrieve(let threadID, let runID), .modify(let threadID, let runID): return "\(version)/threads/\(threadID)/runs/\(runID)"
+         case .cancel(let threadID, let runID): return "\(version)/threads/\(threadID)/runs/\(runID)/cancel"
+         case .submitToolOutput(let threadID, let runID): return "\(version)/threads/\(threadID)/runs/\(runID)/submit_tool_outputs"
+         case .createThreadAndRun: return "\(version)/threads/runs"
          }
       case .runStep(let category):
          switch category {
-         case .retrieve(let threadID, let runID, let stepID): return "/\(version)/threads/\(threadID)/runs/\(runID)/steps/\(stepID)"
-         case .list(let threadID, let runID): return "/\(version)/threads/\(threadID)/runs/\(runID)/steps"
+         case .retrieve(let threadID, let runID, let stepID): return "\(version)/threads/\(threadID)/runs/\(runID)/steps/\(stepID)"
+         case .list(let threadID, let runID): return "\(version)/threads/\(threadID)/runs/\(runID)/steps"
          }
       case .thread(let category):
          switch category {
-         case .create: return "/\(version)/threads"
-         case .retrieve(let threadID), .modify(let threadID), .delete(let threadID): return "/\(version)/threads/\(threadID)"
+         case .create: return "\(version)/threads"
+         case .retrieve(let threadID), .modify(let threadID), .delete(let threadID): return "\(version)/threads/\(threadID)"
          }
       case .vectorStore(let category):
          switch category {
-         case .create, .list: return "/\(version)/vector_stores"
-         case .retrieve(let vectorStoreID), .modify(let vectorStoreID), .delete(let vectorStoreID): return "/\(version)/vector_stores/\(vectorStoreID)"
+         case .create, .list: return "\(version)/vector_stores"
+         case .retrieve(let vectorStoreID), .modify(let vectorStoreID), .delete(let vectorStoreID): return "\(version)/vector_stores/\(vectorStoreID)"
          }
       case .vectorStoreFile(let category):
          switch category {
-         case .create(let vectorStoreID), .list(let vectorStoreID): return "/\(version)/vector_stores/\(vectorStoreID)/files"
-         case .retrieve(let vectorStoreID, let fileID), .delete(let vectorStoreID, let fileID): return "/\(version)/vector_stores/\(vectorStoreID)/files/\(fileID)"
+         case .create(let vectorStoreID), .list(let vectorStoreID): return "\(version)/vector_stores/\(vectorStoreID)/files"
+         case .retrieve(let vectorStoreID, let fileID), .delete(let vectorStoreID, let fileID): return "\(version)/vector_stores/\(vectorStoreID)/files/\(fileID)"
          }
       case .vectorStoreFileBatch(let category):
          switch category {
-         case .create(let vectorStoreID): return"/\(version)/vector_stores/\(vectorStoreID)/file_batches"
+         case .create(let vectorStoreID): return"\(version)/vector_stores/\(vectorStoreID)/file_batches"
          case .retrieve(let vectorStoreID, let batchID): return "\(version)/vector_stores/\(vectorStoreID)/file_batches/\(batchID)"
-         case .cancel(let vectorStoreID, let batchID): return "/\(version)/vector_stores/\(vectorStoreID)/file_batches/\(batchID)/cancel"
-         case .list(let vectorStoreID, let batchID): return "/\(version)/vector_stores/\(vectorStoreID)/file_batches/\(batchID)/files"
+         case .cancel(let vectorStoreID, let batchID): return "\(version)/vector_stores/\(vectorStoreID)/file_batches/\(batchID)/cancel"
+         case .list(let vectorStoreID, let batchID): return "\(version)/vector_stores/\(vectorStoreID)/file_batches/\(batchID)/files"
          }
       }
    }

--- a/Sources/OpenAI/Public/Service/DefaultOpenAIService.swift
+++ b/Sources/OpenAI/Public/Service/DefaultOpenAIService.swift
@@ -11,6 +11,7 @@ struct DefaultOpenAIService: OpenAIService {
    
    let session: URLSession
    let decoder: JSONDecoder
+   let openAIEnvironment: OpenAIEnvironment
    
    private let sessionID = UUID().uuidString
    /// [authentication](https://platform.openai.com/docs/api-reference/authentication)
@@ -40,9 +41,11 @@ struct DefaultOpenAIService: OpenAIService {
       self.apiKey = .bearer(apiKey)
       self.organizationID = organizationID
       self.extraHeaders = extraHeaders
-      OpenAIAPI.overrideBaseURL = baseURL
-      OpenAIAPI.proxyPath = proxyPath
-      OpenAIAPI.overrideVersion = overrideVersion
+      self.openAIEnvironment = OpenAIEnvironment(
+          baseURL: baseURL ?? "https://api.openai.com",
+          proxyPath: proxyPath,
+          version: overrideVersion ?? "v1"
+      )
       self.debugEnabled = debugEnabled
    }
    
@@ -52,7 +55,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: AudioTranscriptionParameters)
       async throws -> AudioObject
    {
-      let request = try OpenAIAPI.audio(.transcriptions).multiPartRequest(apiKey: apiKey, organizationID: organizationID, method: .post,  params: parameters)
+      let request = try OpenAIAPI.audio(.transcriptions).multiPartRequest(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post,  params: parameters)
       return try await fetch(debugEnabled: debugEnabled, type: AudioObject.self, with: request)
    }
    
@@ -60,7 +63,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: AudioTranslationParameters)
       async throws -> AudioObject
    {
-      let request = try OpenAIAPI.audio(.translations).multiPartRequest(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters)
+      let request = try OpenAIAPI.audio(.translations).multiPartRequest(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(debugEnabled: debugEnabled, type: AudioObject.self, with: request)
    }
    
@@ -68,7 +71,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: AudioSpeechParameters)
       async throws -> AudioSpeechObject
    {
-      let request = try OpenAIAPI.audio(.speech).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.audio(.speech).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
       let data = try await fetchAudio(with: request)
       return AudioSpeechObject(output: data)
    }
@@ -81,7 +84,7 @@ struct DefaultOpenAIService: OpenAIService {
    {
       var chatParameters = parameters
       chatParameters.stream = false
-      let request = try OpenAIAPI.chat.request(apiKey: apiKey, organizationID: organizationID, method: .post, params: chatParameters, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.chat.request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: chatParameters, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: ChatCompletionObject.self, with: request)
    }
    
@@ -91,7 +94,7 @@ struct DefaultOpenAIService: OpenAIService {
    {
       var chatParameters = parameters
       chatParameters.stream = true
-      let request = try OpenAIAPI.chat.request(apiKey: apiKey, organizationID: organizationID, method: .post, params: chatParameters, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.chat.request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: chatParameters, extraHeaders: extraHeaders)
       return try await fetchStream(debugEnabled: debugEnabled, type: ChatCompletionChunkObject.self, with: request)
    }
    
@@ -101,7 +104,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: EmbeddingParameter)
       async throws -> OpenAIResponse<EmbeddingObject>
    {
-      let request = try OpenAIAPI.embeddings.request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.embeddings.request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<EmbeddingObject>.self, with: request)
    }
    
@@ -111,7 +114,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: FineTuningJobParameters)
       async throws -> FineTuningJobObject
    {
-      let request = try OpenAIAPI.fineTuning(.create).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.fineTuning(.create).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: FineTuningJobObject.self, with: request)
    }
    
@@ -129,7 +132,7 @@ struct DefaultOpenAIService: OpenAIService {
          queryItems = [.init(name: "limit", value: "\(limit)")]
       }
       
-      let request = try OpenAIAPI.fineTuning(.list).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.fineTuning(.list).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, queryItems: queryItems, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<FineTuningJobObject>.self, with: request)
    }
    
@@ -137,7 +140,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> FineTuningJobObject
    {
-      let request = try OpenAIAPI.fineTuning(.retrieve(jobID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.fineTuning(.retrieve(jobID: id)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: FineTuningJobObject.self, with: request)
    }
    
@@ -145,7 +148,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> FineTuningJobObject
    {
-      let request = try OpenAIAPI.fineTuning(.cancel(jobID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .post, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.fineTuning(.cancel(jobID: id)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: FineTuningJobObject.self, with: request)
    }
    
@@ -163,7 +166,7 @@ struct DefaultOpenAIService: OpenAIService {
       } else if let limit {
          queryItems = [.init(name: "limit", value: "\(limit)")]
       }
-      let request = try OpenAIAPI.fineTuning(.events(jobID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.fineTuning(.events(jobID: id)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, queryItems: queryItems, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<FineTuningJobEventObject>.self, with: request)
    }
    
@@ -172,7 +175,7 @@ struct DefaultOpenAIService: OpenAIService {
    func listFiles()
       async throws -> OpenAIResponse<FileObject>
    {
-      let request = try OpenAIAPI.file(.list).request(apiKey: apiKey, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.file(.list).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<FileObject>.self, with: request)
    }
    
@@ -180,7 +183,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: FileParameters)
       async throws -> FileObject
    {
-      let request = try OpenAIAPI.file(.upload).multiPartRequest(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters)
+      let request = try OpenAIAPI.file(.upload).multiPartRequest(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(debugEnabled: debugEnabled, type: FileObject.self, with: request)
    }
    
@@ -188,7 +191,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> DeletionStatus
    {
-      let request = try OpenAIAPI.file(.delete(fileID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .delete, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.file(.delete(fileID: id)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .delete, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
    }
    
@@ -196,7 +199,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> FileObject
    {
-      let request = try OpenAIAPI.file(.retrieve(fileID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.file(.retrieve(fileID: id)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: FileObject.self, with: request)
    }
    
@@ -204,7 +207,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> [[String: Any]]
    {
-      let request = try OpenAIAPI.file(.retrieveFileContent(fileID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.file(.retrieveFileContent(fileID: id)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
       return try await fetchContentsOfFile(request: request)
    }
    
@@ -214,7 +217,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: ImageCreateParameters)
       async throws -> OpenAIResponse<ImageObject>
    {
-      let request = try OpenAIAPI.images(.generations).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.images(.generations).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<ImageObject>.self,  with: request)
    }
    
@@ -222,7 +225,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: ImageEditParameters)
       async throws -> OpenAIResponse<ImageObject>
    {
-      let request = try OpenAIAPI.images(.edits).multiPartRequest(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters)
+      let request = try OpenAIAPI.images(.edits).multiPartRequest(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<ImageObject>.self, with: request)
    }
    
@@ -230,7 +233,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: ImageVariationParameters)
       async throws -> OpenAIResponse<ImageObject>
    {
-      let request = try OpenAIAPI.images(.variations).multiPartRequest(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters)
+      let request = try OpenAIAPI.images(.variations).multiPartRequest(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<ImageObject>.self, with: request)
    }
    
@@ -239,7 +242,7 @@ struct DefaultOpenAIService: OpenAIService {
    func listModels()
       async throws -> OpenAIResponse<ModelObject>
    {
-      let request = try OpenAIAPI.model(.list).request(apiKey: apiKey, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.model(.list).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<ModelObject>.self,  with: request)
    }
    
@@ -247,7 +250,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> ModelObject
    {
-      let request = try OpenAIAPI.model(.retrieve(modelID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.model(.retrieve(modelID: id)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: ModelObject.self,  with: request)
    }
    
@@ -255,7 +258,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> DeletionStatus
    {
-      let request = try OpenAIAPI.model(.deleteFineTuneModel(modelID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .delete, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.model(.deleteFineTuneModel(modelID: id)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .delete, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self,  with: request)
    }
    
@@ -265,7 +268,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: ModerationParameter<String>)
       async throws -> ModerationObject
    {
-      let request = try OpenAIAPI.moderations.request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.moderations.request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: ModerationObject.self, with: request)
    }
    
@@ -273,7 +276,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: ModerationParameter<[String]>)
       async throws -> ModerationObject
    {
-      let request = try OpenAIAPI.moderations.request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.moderations.request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: ModerationObject.self, with: request)
    }
    
@@ -283,7 +286,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: AssistantParameters)
       async throws -> AssistantObject
    {
-      let request = try OpenAIAPI.assistant(.create).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.assistant(.create).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: AssistantObject.self, with: request)
    }
    
@@ -291,7 +294,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> AssistantObject
    {
-      let request = try OpenAIAPI.assistant(.retrieve(assistantID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.assistant(.retrieve(assistantID: id)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: AssistantObject.self, with: request)
    }
    
@@ -300,7 +303,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: AssistantParameters)
       async throws -> AssistantObject
    {
-      let request = try OpenAIAPI.assistant(.modify(assistantID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.assistant(.modify(assistantID: id)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: AssistantObject.self, with: request)
    }
    
@@ -308,7 +311,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> DeletionStatus
    {
-      let request = try OpenAIAPI.assistant(.delete(assistantID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.assistant(.delete(assistantID: id)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
    }
    
@@ -332,7 +335,7 @@ struct DefaultOpenAIService: OpenAIService {
       if let before {
          queryItems.append(.init(name: "before", value: before))
       }
-      let request = try OpenAIAPI.assistant(.list).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.assistant(.list).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<AssistantObject>.self, with: request)
    }
    
@@ -342,14 +345,14 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: CreateThreadParameters)
       async throws -> ThreadObject
    {
-      let request = try OpenAIAPI.thread(.create).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.thread(.create).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: ThreadObject.self, with: request)
    }
    
    func retrieveThread(id: String)
       async throws -> ThreadObject
    {
-      let request = try OpenAIAPI.thread(.retrieve(threadID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.thread(.retrieve(threadID: id)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: ThreadObject.self, with: request)
    }
    
@@ -358,7 +361,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: ModifyThreadParameters)
       async throws -> ThreadObject
    {
-      let request = try OpenAIAPI.thread(.modify(threadID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.thread(.modify(threadID: id)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: ThreadObject.self, with: request)
    }
    
@@ -366,7 +369,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> DeletionStatus
    {
-      let request = try OpenAIAPI.thread(.delete(threadID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.thread(.delete(threadID: id)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
    }
    
@@ -377,7 +380,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: MessageParameter)
       async throws -> MessageObject
    {
-      let request = try OpenAIAPI.message(.create(threadID: threadID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.message(.create(threadID: threadID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: MessageObject.self, with: request)
    }
    
@@ -386,7 +389,7 @@ struct DefaultOpenAIService: OpenAIService {
       messageID: String)
       async throws -> MessageObject
    {
-      let request = try OpenAIAPI.message(.retrieve(threadID: threadID, messageID: messageID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.message(.retrieve(threadID: threadID, messageID: messageID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: MessageObject.self, with: request)
    }
    
@@ -396,7 +399,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: ModifyMessageParameters)
       async throws -> MessageObject
    {
-      let request = try OpenAIAPI.message(.modify(threadID: threadID, messageID: messageID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.message(.modify(threadID: threadID, messageID: messageID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: MessageObject.self, with: request)
    }
    
@@ -405,7 +408,7 @@ struct DefaultOpenAIService: OpenAIService {
       messageID: String)
       async throws -> DeletionStatus
    {
-      let request = try OpenAIAPI.message(.delete(threadID: threadID, messageID: messageID)).request(apiKey: apiKey, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.message(.delete(threadID: threadID, messageID: messageID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
    }
    
@@ -434,7 +437,7 @@ struct DefaultOpenAIService: OpenAIService {
       if let runID {
          queryItems.append(.init(name: "run_id", value: runID))
       }
-      let request = try OpenAIAPI.message(.list(threadID: threadID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.message(.list(threadID: threadID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<MessageObject>.self, with: request)
    }
    
@@ -445,7 +448,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: RunParameter)
       async throws -> RunObject
    {
-      let request = try OpenAIAPI.run(.create(threadID: threadID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.run(.create(threadID: threadID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
    }
    
@@ -454,7 +457,7 @@ struct DefaultOpenAIService: OpenAIService {
       runID: String)
       async throws -> RunObject
    {
-      let request = try OpenAIAPI.run(.retrieve(threadID: threadID, runID: runID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.run(.retrieve(threadID: threadID, runID: runID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
    }
    
@@ -464,7 +467,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: ModifyRunParameters)
       async throws -> RunObject
    {
-      let request = try OpenAIAPI.run(.modify(threadID: threadID, runID: runID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.run(.modify(threadID: threadID, runID: runID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
    }
    
@@ -489,7 +492,7 @@ struct DefaultOpenAIService: OpenAIService {
       if let before {
          queryItems.append(.init(name: "before", value: before))
       }
-      let request = try OpenAIAPI.run(.list(threadID: threadID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.run(.list(threadID: threadID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<RunObject>.self, with: request)
    }
    
@@ -498,7 +501,7 @@ struct DefaultOpenAIService: OpenAIService {
       runID: String)
       async throws -> RunObject
    {
-      let request = try OpenAIAPI.run(.cancel(threadID: threadID, runID: runID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.run(.cancel(threadID: threadID, runID: runID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
    }
    
@@ -508,7 +511,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: RunToolsOutputParameter)
       async throws -> RunObject
    {
-      let request = try OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
    }
    
@@ -516,7 +519,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: CreateThreadAndRunParameter)
       async throws -> RunObject
    {
-      let request = try OpenAIAPI.run(.createThreadAndRun).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.run(.createThreadAndRun).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
    }
    
@@ -528,7 +531,7 @@ struct DefaultOpenAIService: OpenAIService {
       stepID: String)
       async throws -> RunStepObject
    {
-      let request = try OpenAIAPI.runStep(.retrieve(threadID: threadID, runID: runID, stepID: stepID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.runStep(.retrieve(threadID: threadID, runID: runID, stepID: stepID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: RunStepObject.self, with: request)
    }
    
@@ -554,7 +557,7 @@ struct DefaultOpenAIService: OpenAIService {
       if let before {
          queryItems.append(.init(name: "before", value: before))
       }
-      let request = try OpenAIAPI.runStep(.list(threadID: threadID, runID: runID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.runStep(.list(threadID: threadID, runID: runID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<RunStepObject>.self, with: request)
    }
    
@@ -565,7 +568,7 @@ struct DefaultOpenAIService: OpenAIService {
    {
       var runParameters = parameters
       runParameters.stream = true
-      let request = try OpenAIAPI.run(.create(threadID: threadID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: runParameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.run(.create(threadID: threadID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: runParameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetchAssistantStreamEvents(with: request, debugEnabled: debugEnabled)
    }
    
@@ -574,7 +577,7 @@ struct DefaultOpenAIService: OpenAIService {
    async throws -> AsyncThrowingStream<AssistantStreamEvent, Error> {
       var runParameters = parameters
       runParameters.stream = true
-      let request = try OpenAIAPI.run(.createThreadAndRun).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.run(.createThreadAndRun).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetchAssistantStreamEvents(with: request, debugEnabled: debugEnabled)
    }
    
@@ -586,7 +589,7 @@ struct DefaultOpenAIService: OpenAIService {
    {
       var runToolsOutputParameter = parameters
       runToolsOutputParameter.stream = true
-      let request = try OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: runToolsOutputParameter, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: runToolsOutputParameter, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetchAssistantStreamEvents(with: request, debugEnabled: debugEnabled)
    }
    
@@ -596,7 +599,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: BatchParameter)
       async throws -> BatchObject
    {
-      let request = try OpenAIAPI.batch(.create).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.batch(.create).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: BatchObject.self, with: request)
    }
    
@@ -604,7 +607,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> BatchObject
    {
-      let request = try OpenAIAPI.batch(.retrieve(batchID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.batch(.retrieve(batchID: id)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: BatchObject.self, with: request)
    }
    
@@ -612,7 +615,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> BatchObject
    {
-      let request = try OpenAIAPI.batch(.cancel(batchID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .post, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.batch(.cancel(batchID: id)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: BatchObject.self, with: request)
    }
    
@@ -628,7 +631,7 @@ struct DefaultOpenAIService: OpenAIService {
       if let after {
          queryItems.append(.init(name: "after", value: after))
       }
-      let request = try OpenAIAPI.batch(.list).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.batch(.list).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, queryItems: queryItems, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<BatchObject>.self, with: request)
    }
    
@@ -638,7 +641,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: VectorStoreParameter)
       async throws -> VectorStoreObject
    {
-      let request = try OpenAIAPI.vectorStore(.create).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.vectorStore(.create).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreObject.self, with: request)
    }
    
@@ -662,7 +665,7 @@ struct DefaultOpenAIService: OpenAIService {
       if let before {
          queryItems.append(.init(name: "before", value: before))
       }
-      let request = try OpenAIAPI.vectorStore(.list).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.vectorStore(.list).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<VectorStoreObject>.self, with: request)
    }
    
@@ -670,7 +673,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String) async throws
       -> VectorStoreObject
    {
-      let request = try OpenAIAPI.vectorStore(.retrieve(vectorStoreID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.vectorStore(.retrieve(vectorStoreID: id)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreObject.self, with: request)
    }
    
@@ -679,7 +682,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> VectorStoreObject
    {
-      let request = try OpenAIAPI.vectorStore(.modify(vectorStoreID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.vectorStore(.modify(vectorStoreID: id)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreObject.self, with: request)
    }
    
@@ -687,7 +690,7 @@ struct DefaultOpenAIService: OpenAIService {
       id: String)
       async throws -> DeletionStatus
    {
-      let request = try OpenAIAPI.vectorStore(.modify(vectorStoreID: id)).request(apiKey: apiKey, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.vectorStore(.modify(vectorStoreID: id)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
    }
    
@@ -698,7 +701,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: VectorStoreFileParameter)
    async throws -> VectorStoreFileObject
    {
-      let request = try OpenAIAPI.vectorStoreFile(.create(vectorStoreID: vectorStoreID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.vectorStoreFile(.create(vectorStoreID: vectorStoreID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreFileObject.self, with: request)
    }
    
@@ -727,7 +730,7 @@ struct DefaultOpenAIService: OpenAIService {
       if let filter {
          queryItems.append(.init(name: "filter", value: filter))
       }
-      let request = try OpenAIAPI.vectorStoreFile(.list(vectorStoreID: vectorStoreID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.vectorStoreFile(.list(vectorStoreID: vectorStoreID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<VectorStoreFileObject>.self, with: request)
    }
    
@@ -736,7 +739,7 @@ struct DefaultOpenAIService: OpenAIService {
       fileID: String)
       async throws -> VectorStoreFileObject
    {
-      let request = try OpenAIAPI.vectorStoreFile(.retrieve(vectorStoreID: vectorStoreID, fileID: fileID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.vectorStoreFile(.retrieve(vectorStoreID: vectorStoreID, fileID: fileID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreFileObject.self, with: request)
    }
    
@@ -745,7 +748,7 @@ struct DefaultOpenAIService: OpenAIService {
       fileID: String)
       async throws -> DeletionStatus
    {
-      let request = try OpenAIAPI.vectorStoreFile(.delete(vectorStoreID: vectorStoreID, fileID: fileID)).request(apiKey: apiKey, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.vectorStoreFile(.delete(vectorStoreID: vectorStoreID, fileID: fileID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .delete, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
    }
    
@@ -756,7 +759,7 @@ struct DefaultOpenAIService: OpenAIService {
       parameters: VectorStoreFileBatchParameter)
       async throws -> VectorStoreFileBatchObject
    {
-      let request = try OpenAIAPI.vectorStoreFileBatch(.create(vectorStoreID: vectorStoreID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.vectorStoreFileBatch(.create(vectorStoreID: vectorStoreID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, params: parameters, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreFileBatchObject.self, with: request)
    }
    
@@ -765,7 +768,7 @@ struct DefaultOpenAIService: OpenAIService {
       batchID: String)
       async throws -> VectorStoreFileBatchObject
    {
-      let request = try OpenAIAPI.vectorStoreFileBatch(.retrieve(vectorStoreID: vectorStoreID, batchID: batchID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.vectorStoreFileBatch(.retrieve(vectorStoreID: vectorStoreID, batchID: batchID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreFileBatchObject.self, with: request)
    }
    
@@ -774,7 +777,7 @@ struct DefaultOpenAIService: OpenAIService {
       batchID: String)
       async throws -> VectorStoreFileBatchObject
    {
-      let request = try OpenAIAPI.vectorStoreFileBatch(.cancel(vectorStoreID: vectorStoreID, batchID: batchID)).request(apiKey: apiKey, organizationID: organizationID, method: .post, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.vectorStoreFileBatch(.cancel(vectorStoreID: vectorStoreID, batchID: batchID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .post, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: VectorStoreFileBatchObject.self, with: request)
    }
    
@@ -804,7 +807,7 @@ struct DefaultOpenAIService: OpenAIService {
       if let filter {
          queryItems.append(.init(name: "filter", value: filter))
       }
-      let request = try OpenAIAPI.vectorStoreFileBatch(.list(vectorStoreID: vectorStoreID, batchID: batchID)).request(apiKey: apiKey, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
+      let request = try OpenAIAPI.vectorStoreFileBatch(.list(vectorStoreID: vectorStoreID, batchID: batchID)).request(apiKey: apiKey, openAIEnvironment: openAIEnvironment, organizationID: organizationID, method: .get, queryItems: queryItems, betaHeaderField: Self.assistantsBetaV2, extraHeaders: extraHeaders)
       return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<VectorStoreFileObject>.self, with: request)
    }
 }

--- a/Sources/OpenAI/Public/Service/OpenAIService.swift
+++ b/Sources/OpenAI/Public/Service/OpenAIService.swift
@@ -57,6 +57,22 @@ public enum Authorization {
     }
 }
 
+/// Represents the configuration for interacting with the OpenAI API.
+public struct OpenAIEnvironment {
+    
+    /// The base URL for the OpenAI API.
+    /// Example: "https://api.openai.com"
+    let baseURL: String
+    
+    /// An optional path for proxying requests.
+    /// Example: "/proxy-path"
+    let proxyPath: String?
+    
+    /// An optional version of the OpenAI API to use.
+    /// Example: "v1"
+    let version: String?
+}
+
 // MARK: Service
 
 /// A protocol defining the required services for interacting with OpenAI's API.
@@ -75,6 +91,9 @@ public protocol OpenAIService {
    /// This decoder is used to parse the JSON responses returned by the API
    /// into model objects that conform to the `Decodable` protocol.
    var decoder: JSONDecoder { get }
+   
+   /// A computed property representing the current OpenAI environment configuration.
+   var openAIEnvironment: OpenAIEnvironment { get }
    
    // MARK: Audio
    

--- a/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
+++ b/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
@@ -53,7 +53,7 @@ public class OpenAIServiceFactory {
       urlSessionConfiguration: URLSessionConfiguration = .default,
       decoder: JSONDecoder = .init(),
       debugEnabled: Bool = false)
-   -> OpenAIService
+      -> OpenAIService
    {
       DefaultOpenAIAzureService(
          azureConfiguration: azureConfiguration,
@@ -87,7 +87,7 @@ public class OpenAIServiceFactory {
       aiproxyServiceURL: String? = nil,
       aiproxyClientID: String? = nil,
       debugEnabled: Bool = false)
-   -> OpenAIService
+      -> OpenAIService
    {
       AIProxyService(
         partialKey: aiproxyPartialKey,
@@ -132,7 +132,7 @@ public class OpenAIServiceFactory {
    ///   - apiKey: The optional API key required for authentication.
    ///   - baseURL: The local host URL.  e.g "https://api.groq.com" or "https://generativelanguage.googleapis.com"
    ///   - proxyPath: The proxy path e.g `openai`
-   ///   - overrideVersion: The API version. defaults to `V1`
+   ///   - overrideVersion: The API version. defaults to `v1`
    ///   - extraHeaders: Additional headers needed for the request. Do not provide API key in these headers.
    ///   - debugEnabled: If `true` service prints event on DEBUG builds, default to `false`.
    ///


### PR DESCRIPTION
Having static properties in the `OpenAIAPI` enum was a bad coding choice, this choice was took aiming to support so many configurations, such Gemini, Groq etc support.

This is a large change but will make the library more scalable.

Changes has been done commit by commit for each service, Azure, Ollama, OpenAI and AIProxy

