### PR TITLE
DeepSeek demo

### DIFF
--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ApiKeyIntroView.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ApiKeyIntroView.swift
@@ -10,7 +10,9 @@ import SwiftOpenAI
 
 struct ApiKeyIntroView: View {
    
-   @State private var apiKey = ""
+   let service = OpenAIServiceFactory.service(apiKey: "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", overrideBaseURL: "https://api.deepseek.com", debugEnabled: true)
+   
+   @State private var apiKey = "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"
    @State private var organizationIdentifier = ""
    @State private var localOrganizationID: String? = nil
    
@@ -29,7 +31,7 @@ struct ApiKeyIntroView: View {
             }
             .padding()
             .textFieldStyle(.roundedBorder)
-            NavigationLink(destination: OptionsListView(openAIService: OpenAIServiceFactory.service(apiKey: apiKey, organizationID: localOrganizationID, debugEnabled: true), options: OptionsListView.APIOption.allCases.filter({ $0 != .localChat }))) {
+            NavigationLink(destination: OptionsListView(openAIService: service, options: OptionsListView.APIOption.allCases.filter({ $0 != .localChat }))) {
                Text("Continue")
                   .padding()
                   .padding(.horizontal, 48)

--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ApiKeyIntroView.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ApiKeyIntroView.swift
@@ -10,9 +10,7 @@ import SwiftOpenAI
 
 struct ApiKeyIntroView: View {
    
-   let service = OpenAIServiceFactory.service(apiKey: "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", overrideBaseURL: "https://api.deepseek.com", debugEnabled: true)
-   
-   @State private var apiKey = "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"
+   @State private var apiKey = ""
    @State private var organizationIdentifier = ""
    @State private var localOrganizationID: String? = nil
    
@@ -31,7 +29,7 @@ struct ApiKeyIntroView: View {
             }
             .padding()
             .textFieldStyle(.roundedBorder)
-            NavigationLink(destination: OptionsListView(openAIService: service, options: OptionsListView.APIOption.allCases.filter({ $0 != .localChat }))) {
+            NavigationLink(destination: OptionsListView(openAIService: OpenAIServiceFactory.service(apiKey: apiKey, organizationID: localOrganizationID, debugEnabled: true), options: OptionsListView.APIOption.allCases.filter({ $0 != .localChat }))) {
                Text("Continue")
                   .padding()
                   .padding(.horizontal, 48)

--- a/README.md
+++ b/README.md
@@ -3289,6 +3289,7 @@ For more inofrmation about the `OpenRouter` api visit its [documentation](https:
 
 The [DeepSeek](https://api-docs.deepseek.com/) API uses an API format compatible with OpenAI. By modifying the configuration, you can use SwiftOpenAI to access the DeepSeek API.
 
+```swift
 // Creating the service
 
 let apiKey = "your_api_key"
@@ -3301,6 +3302,7 @@ let service = OpenAIServiceFactory.service(
 let prompt = "What is the Manhattan project?"
 let parameters = ChatCompletionParameters(messages: [.init(role: .user, content: .text(prompt))], model: .custom("deepseek-reasoner"))
 let stream = service.startStreamedChat(parameters: parameters)
+```
 
 For more inofrmation about the `DeepSeek` api visit its [documentation](https://api-docs.deepseek.com).
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ An open-source Swift package designed for effortless interaction with OpenAI's p
    - [Vector store File](#vector-store-file)
    - [Vector store File Batch](#vector-store-file-batch)
 
-
 ## Getting an API Key
 
 ⚠️ **Important**
@@ -105,6 +104,7 @@ SwiftOpenAI supports various providers that are OpenAI-compatible, including but
 - [Ollama](#ollama)
 - [Groq](#groq)
 - [OpenRouter](#openRouter)
+- [DeepSeek](#deepseek)
 - [AIProxy](#aiproxy)
 
 Check OpenAIServiceFactory for convenience initializers that you can use to provide custom URLs.
@@ -3257,9 +3257,9 @@ For Supported API's using Groq visit its [documentation](https://console.groq.co
 
 ## OpenRouter
 
-[OpenRouter](https://openrouter.ai/docs/quick-start) provides an OpenAI-compatible completion API to 314 models & providers that you can call directly, or using the OpenAI SDK. Additionally, some third-party SDKs are available.
-
 <img width="734" alt="Image" src="https://github.com/user-attachments/assets/2d658d07-0b41-4b5f-a094-ec7856f6fe98" />
+
+[OpenRouter](https://openrouter.ai/docs/quick-start) provides an OpenAI-compatible completion API to 314 models & providers that you can call directly, or using the OpenAI SDK. Additionally, some third-party SDKs are available.
 
 ```swift
 
@@ -3274,11 +3274,35 @@ let servcie = OpenAIServiceFactory.service(apiKey: apiKey,
          "X-Title": "<YOUR_SITE_NAME>"  // Optional. Site title for rankings on openrouter.ai.
    ])
 
-// Making a 
+// Making a request
+
 let prompt = "What is the Manhattan project?"
 let parameters = ChatCompletionParameters(messages: [.init(role: .user, content: .text(prompt))], model: .custom("deepseek/deepseek-r1:free"))
 let stream = service.startStreamedChat(parameters: parameters)
 ```
+
+For more inofrmation about the `OpenRouter` api visit its [documentation](https://openrouter.ai/docs/quick-start).
+
+## DeepSeek
+
+![Image](https://github.com/user-attachments/assets/7733f011-691a-4de7-b715-c090e3647304)
+
+The [DeepSeek](https://api-docs.deepseek.com/) API uses an API format compatible with OpenAI. By modifying the configuration, you can use SwiftOpenAI to access the DeepSeek API.
+
+// Creating the service
+
+let apiKey = "your_api_key"
+let service = OpenAIServiceFactory.service(
+   apiKey: apiKey,
+   overrideBaseURL: "https://api.deepseek.com")
+
+// Making a request
+
+let prompt = "What is the Manhattan project?"
+let parameters = ChatCompletionParameters(messages: [.init(role: .user, content: .text(prompt))], model: .custom("deepseek-reasoner"))
+let stream = service.startStreamedChat(parameters: parameters)
+
+For more inofrmation about the `DeepSeek` api visit its [documentation](https://api-docs.deepseek.com).
 
 ## Gemini
 


### PR DESCRIPTION
## DeepSeek

![Image](https://github.com/user-attachments/assets/7733f011-691a-4de7-b715-c090e3647304)

The [DeepSeek](https://api-docs.deepseek.com/) API uses an API format compatible with OpenAI. By modifying the configuration, you can use SwiftOpenAI to access the DeepSeek API.

```swift
// Creating the service

let apiKey = "your_api_key"
let service = OpenAIServiceFactory.service(
   apiKey: apiKey,
   overrideBaseURL: "https://api.deepseek.com")

// Making a request

let prompt = "What is the Manhattan project?"
let parameters = ChatCompletionParameters(messages: [.init(role: .user, content: .text(prompt))], model: .custom("deepseek-reasoner"))
let stream = service.startStreamedChat(parameters: parameters)
```

For more inofrmation about the `DeepSeek` api visit its [documentation](https://api-docs.deepseek.com).
