### PR TITLE
Adding configuration instruction to READ.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,20 @@ let oganizationID = "your_organixation_id"
 let service = OpenAIServiceFactory.service(apiKey: apiKey, organizationID: oganizationID)
 ```
 
+https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1408259-timeoutintervalforrequest
+
+For reasoning models, ensure that you extend the timeoutIntervalForRequest in the URL session configuration to a higher value. The default is 60 seconds, which may be insufficient, as requests to reasoning models can take longer to process and respond.
+
+To configure it:
+
+```swift
+let apiKey = "your_openai_api_key_here"
+let organizationID = "your_organization_id"
+let configuration = URLSessionConfiguration.default
+configuration.timeoutIntervalForRequest = 360 // e.g., 360 seconds or more.
+let service = OpenAIServiceFactory.service(apiKey: apiKey, organizationID: organizationID, configuration: configuration)
+```
+
 That's all you need to begin accessing the full range of OpenAI endpoints.
 
 ### How to get the status code of network errors

--- a/Sources/OpenAI/Public/Service/DefaultOpenAIService.swift
+++ b/Sources/OpenAI/Public/Service/DefaultOpenAIService.swift
@@ -32,7 +32,7 @@ struct DefaultOpenAIService: OpenAIService {
       proxyPath: String? = nil,
       overrideVersion: String? = nil,
       extraHeaders: [String: String]? = nil,
-      configuration: URLSessionConfiguration = .default,
+      configuration: URLSessionConfiguration,
       decoder: JSONDecoder = .init(),
       debugEnabled: Bool)
    {

--- a/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
+++ b/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
@@ -140,6 +140,7 @@ public class OpenAIServiceFactory {
    public static func service(
       apiKey: String,
       overrideBaseURL: String,
+      configuration: URLSessionConfiguration = .default,
       proxyPath: String? = nil,
       overrideVersion: String? = nil,
       extraHeaders: [String: String]? = nil,
@@ -152,6 +153,7 @@ public class OpenAIServiceFactory {
          proxyPath: proxyPath,
          overrideVersion: overrideVersion,
          extraHeaders: extraHeaders,
+         configuration: configuration,
          debugEnabled: debugEnabled)
    }
 }


### PR DESCRIPTION
For reasoning models, ensure that you extend the timeoutIntervalForRequest in the URL session configuration to a higher value. The default is 60 seconds, which may be insufficient, as requests to reasoning models can take longer to process and respond.

To configure it:

```swift
let apiKey = "your_openai_api_key_here"
let organizationID = "your_organization_id"
let configuration = URLSessionConfiguration.default
configuration.timeoutIntervalForRequest = 360 // e.g., 360 seconds or more.
let service = OpenAIServiceFactory.service(apiKey: apiKey, organizationID: organizationID, configuration: configuration)
```