### PR TITLE
Fix MessageParameter for "Create message" request

### DIFF
--- a/Sources/OpenAI/Public/Parameters/Message/MessageParameter.swift
+++ b/Sources/OpenAI/Public/Parameters/Message/MessageParameter.swift
@@ -50,7 +50,7 @@ public struct MessageParameter: Encodable {
    
    /// Enum to represent different content parts (text, image URL, image file).
    public enum ContentItem: Encodable {
-      case text(Text)
+      case text(String)
       case imageURL(ImageURL)
       case imageFile(ImageFile)
       
@@ -74,26 +74,6 @@ public struct MessageParameter: Encodable {
          case text
          case imageURL = "image_url"
          case imageFile = "image_file"
-      }
-   }
-   
-   /// Struct representing a text content part.
-   public struct Text: Encodable {
-      let text: String
-      
-      public init(text: String) {
-         self.text = text
-      }
-      
-      enum CodingKeys: String, CodingKey {
-         case type
-         case text
-      }
-      
-      public func encode(to encoder: Encoder) throws {
-         var container = encoder.container(keyedBy: CodingKeys.self)
-         try container.encode("text", forKey: .type)
-         try container.encode(text, forKey: .text)
       }
    }
    


### PR DESCRIPTION
ContentItem.text should contain String instead of object

Currently it sends following JSON:
```
{
  "content" : [
    {
      "type" : "text",
      "text" : {
        "type": "text",
        "text": "Where is this photo taken?"
      }
    },
    {
      "type" : "image_file",
      "image_file" : {
        "file_id" : "file-LY37xeG7327xbghdpij6mW"
      }
    }
  ],
  "role" : "user"
}
```
Should be
```
{
  "content" : [
    {
      "type" : "text",
      "text" : "Where is this photo taken?"
    },
    {
      "type" : "image_file",
      "image_file" : {
        "file_id" : "file-LY37xeG7327xbghdpij6mW"
      }
    }
  ],
  "role" : "user"
}
```
See https://platform.openai.com/docs/api-reference/messages/createMessage