### PR TITLE
Fix `mask` parameter for `ImageEdit` request

### DIFF
--- a/Sources/OpenAI/Private/Networking/MultipartFormDataBuilder.swift
+++ b/Sources/OpenAI/Private/Networking/MultipartFormDataBuilder.swift
@@ -35,7 +35,7 @@ struct MultipartFormDataBuilder {
 
 enum MultipartFormDataEntry {
    
-   case file(paramName: String, fileName: String?, fileData: Data, contentType: String)
+   case file(paramName: String, fileName: String?, fileData: Data?, contentType: String)
    case string(paramName: String, value: Any?)
 }
 
@@ -47,15 +47,17 @@ extension MultipartFormDataEntry {
       var body = Data()
       switch self {
       case .file(let paramName, let fileName, let fileData, let contentType):
-         body.append("--\(boundary)\r\n")
-         if let fileName = fileName {
-             body.append("Content-Disposition: form-data; name=\"\(paramName)\"; filename=\"\(fileName)\"\r\n")
-         } else {
-             body.append("Content-Disposition: form-data; name=\"\(paramName)\"\r\n")
+         if let fileData {
+            body.append("--\(boundary)\r\n")
+            if let fileName = fileName {
+               body.append("Content-Disposition: form-data; name=\"\(paramName)\"; filename=\"\(fileName)\"\r\n")
+            } else {
+               body.append("Content-Disposition: form-data; name=\"\(paramName)\"\r\n")
+            }
+            body.append("Content-Type: \(contentType)\r\n\r\n")
+            body.append(fileData)
+            body.append("\r\n")
          }
-         body.append("Content-Type: \(contentType)\r\n\r\n")
-         body.append(fileData)
-         body.append("\r\n")
       case .string(let paramName, let value):
          if let value {
             body.append("--\(boundary)\r\n")

--- a/Sources/OpenAI/Public/Parameters/Image/ImageEditParameters.swift
+++ b/Sources/OpenAI/Public/Parameters/Image/ImageEditParameters.swift
@@ -71,7 +71,7 @@ public struct ImageEditParameters: Encodable {
       if imageData == nil {
          assertionFailure("Failed to get image data")
       }
-      if maskData == nil {
+      if mask != nil, maskData == nil {
          assertionFailure("Failed to get mask data")
       }
       
@@ -94,7 +94,7 @@ extension ImageEditParameters: MultipartFormDataParameters {
       MultipartFormDataBuilder(boundary: boundary, entries: [
          .file(paramName: Self.CodingKeys.image.rawValue, fileName: "", fileData: image, contentType: "image/png"),
          .string(paramName: Self.CodingKeys.prompt.rawValue, value: prompt),
-         .string(paramName: Self.CodingKeys.mask.rawValue, value: mask),
+         .file(paramName: Self.CodingKeys.mask.rawValue, fileName: "mask.png", fileData: mask, contentType: "image/png"),
          .string(paramName: Self.CodingKeys.model.rawValue, value: model),
          .string(paramName: Self.CodingKeys.n.rawValue, value: n),
          .string(paramName: Self.CodingKeys.size.rawValue, value: size),


### PR DESCRIPTION
`mask` parameter should be sent as a `file` (instead of a `string`).
It can also be `nil`, so don't throw an assertion error in that case.