### PR TITLE
Implementing cross-platform support by supporting Linux-friendly HTTP clients

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,131 @@
+{
+  "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "333f51104b75d1a5b94cb3b99e4c58a3b442c9f7",
+        "version" : "1.25.2"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "f280fc7676b9940ff2c6598642751ea333c6544f",
+        "version" : "1.2.2"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "a0a57e949a8903563aba4615869310c0ebf14c03",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
+        "version" : "1.6.3"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "0f54d58bb5db9e064f332e8524150de379d1e51c",
+        "version" : "2.82.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "f1f6f772198bee35d99dd145f1513d8581a54f2c",
+        "version" : "1.26.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "4281466512f63d1bd530e33f4aa6993ee7864be0",
+        "version" : "1.36.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "6df102a39c8da5fdc2eae29a0f63546d660866fc",
+        "version" : "2.30.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "cd1e89816d345d2523b11c55654570acd5cd4c56",
+        "version" : "1.24.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "a34201439c74b53f0fd71ef11741af7e7caf01e1",
+        "version" : "1.4.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -16,11 +16,17 @@ let package = Package(
       name: "SwiftOpenAI",
       targets: ["SwiftOpenAI"]),
   ],
+  dependencies: [
+    .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.25.2"),
+  ],
   targets: [
     // Targets are the basic building blocks of a package, defining a module or a test suite.
     // Targets can depend on other targets in this package and products from dependencies.
     .target(
-      name: "SwiftOpenAI"),
+      name: "SwiftOpenAI",
+      dependencies: [
+        .product(name: "AsyncHTTPClient", package: "async-http-client")
+    ]),
     .testTarget(
       name: "SwiftOpenAITests",
       dependencies: ["SwiftOpenAI"]),

--- a/Sources/OpenAI/AIProxy/AIProxyCertificatePinning.swift
+++ b/Sources/OpenAI/AIProxy/AIProxyCertificatePinning.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Lou Zell on 6/23/24.
 //
-
+#if !os(Linux)
 import Foundation
 import OSLog
 
@@ -181,3 +181,4 @@ private func getServerCert(secTrust: SecTrust) -> SecCertificate? {
     return SecTrustGetCertificateAtIndex(secTrust, 0)
   }
 }
+#endif

--- a/Sources/OpenAI/AIProxy/Endpoint+AIProxy.swift
+++ b/Sources/OpenAI/AIProxy/Endpoint+AIProxy.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Lou Zell on 3/26/24.
 //
-
+#if !os(Linux)
 import DeviceCheck
 import Foundation
 import OSLog
@@ -241,4 +241,5 @@ private func copy_mac_address() -> CFData? {
 
   return nil
 }
+#endif
 #endif

--- a/Sources/OpenAI/Azure/DefaultOpenAIAzureService.swift
+++ b/Sources/OpenAI/Azure/DefaultOpenAIAzureService.swift
@@ -6,16 +6,18 @@
 //
 
 import Foundation
+#if os(Linux)
+import FoundationNetworking
+#endif
 
 final public class DefaultOpenAIAzureService: OpenAIService {
 
   public init(
     azureConfiguration: AzureOpenAIConfiguration,
-    urlSessionConfiguration: URLSessionConfiguration = .default,
     decoder: JSONDecoder = .init(),
     debugEnabled: Bool)
   {
-    session = URLSession(configuration: urlSessionConfiguration)
+    self.httpClient = AsyncHTTPClientAdapter.createDefault()
     self.decoder = decoder
     openAIEnvironment = OpenAIEnvironment(
       baseURL: "https://\(azureConfiguration.resourceName)/openai.azure.com",
@@ -27,7 +29,7 @@ final public class DefaultOpenAIAzureService: OpenAIService {
     self.debugEnabled = debugEnabled
   }
 
-  public let session: URLSession
+  public let httpClient: HTTPClient
   public let decoder: JSONDecoder
   public let openAIEnvironment: OpenAIEnvironment
 

--- a/Sources/OpenAI/Azure/DefaultOpenAIAzureService.swift
+++ b/Sources/OpenAI/Azure/DefaultOpenAIAzureService.swift
@@ -14,10 +14,11 @@ final public class DefaultOpenAIAzureService: OpenAIService {
 
   public init(
     azureConfiguration: AzureOpenAIConfiguration,
+    httpClient: HTTPClient,
     decoder: JSONDecoder = .init(),
     debugEnabled: Bool)
   {
-    self.httpClient = AsyncHTTPClientAdapter.createDefault()
+    self.httpClient = httpClient
     self.decoder = decoder
     openAIEnvironment = OpenAIEnvironment(
       baseURL: "https://\(azureConfiguration.resourceName)/openai.azure.com",

--- a/Sources/OpenAI/LocalModelService/LocalModelService.swift
+++ b/Sources/OpenAI/LocalModelService/LocalModelService.swift
@@ -14,11 +14,10 @@ struct LocalModelService: OpenAIService {
     baseURL: String,
     proxyPath: String? = nil,
     overrideVersion: String? = nil,
-    configuration: URLSessionConfiguration = .default,
     decoder: JSONDecoder = .init(),
     debugEnabled: Bool)
   {
-    session = URLSession(configuration: configuration)
+    self.httpClient = AsyncHTTPClientAdapter.createDefault()
     self.decoder = decoder
     self.apiKey = apiKey
     openAIEnvironment = OpenAIEnvironment(baseURL: baseURL, proxyPath: proxyPath, version: overrideVersion ?? "v1")
@@ -49,7 +48,7 @@ struct LocalModelService: OpenAIService {
       "Currently, this API is not supported. We welcome and encourage contributions to our open-source project. Please consider opening an issue or submitting a pull request to add support for this feature.")
   }
 
-  let session: URLSession
+  let httpClient: HTTPClient
   let decoder: JSONDecoder
   let openAIEnvironment: OpenAIEnvironment
 

--- a/Sources/OpenAI/LocalModelService/LocalModelService.swift
+++ b/Sources/OpenAI/LocalModelService/LocalModelService.swift
@@ -14,10 +14,11 @@ struct LocalModelService: OpenAIService {
     baseURL: String,
     proxyPath: String? = nil,
     overrideVersion: String? = nil,
+    httpClient: HTTPClient,
     decoder: JSONDecoder = .init(),
     debugEnabled: Bool)
   {
-    self.httpClient = AsyncHTTPClientAdapter.createDefault()
+    self.httpClient = httpClient
     self.decoder = decoder
     self.apiKey = apiKey
     openAIEnvironment = OpenAIEnvironment(baseURL: baseURL, proxyPath: proxyPath, version: overrideVersion ?? "v1")

--- a/Sources/OpenAI/Private/Networking/AsyncHTTPClientAdapter.swift
+++ b/Sources/OpenAI/Private/Networking/AsyncHTTPClientAdapter.swift
@@ -1,0 +1,131 @@
+//
+//  AsyncHTTPClientAdapter.swift
+//  SwiftOpenAI
+//
+//  Created by Joe Fabisevich on 5/18/25.
+//
+
+import AsyncHTTPClient
+import Foundation
+import NIOCore
+import NIOFoundationCompat
+import NIOHTTP1
+
+/// Adapter that implements HTTPClient protocol using AsyncHTTPClient
+public class AsyncHTTPClientAdapter: HTTPClient {
+    /// The underlying AsyncHTTPClient instance
+    private let client: AsyncHTTPClient.HTTPClient
+    
+    /// Initializes a new AsyncHTTPClientAdapter with the provided AsyncHTTPClient
+    /// - Parameter client: The AsyncHTTPClient instance to use
+    public init(client: AsyncHTTPClient.HTTPClient) {
+        self.client = client
+    }
+    
+    /// Creates a new AsyncHTTPClientAdapter with a default configuration
+    /// - Returns: A new AsyncHTTPClientAdapter instance
+    public static func createDefault() -> AsyncHTTPClientAdapter {
+        let httpClient = AsyncHTTPClient.HTTPClient(
+			eventLoopGroupProvider: .singleton,
+			configuration: AsyncHTTPClient.HTTPClient.Configuration(
+				certificateVerification: .fullVerification,
+				timeout: .init(
+					connect: .seconds(30),
+					read: .seconds(30)
+				),
+				backgroundActivityLogger: nil)
+        )
+        return AsyncHTTPClientAdapter(client: httpClient)
+    }
+    
+    /// Fetches data for a given HTTP request
+    /// - Parameter request: The HTTP request to perform
+    /// - Returns: A tuple containing the data and HTTP response
+    public func data(for request: HTTPRequest) async throws -> (Data, HTTPResponse) {
+        let asyncHTTPClientRequest = try createAsyncHTTPClientRequest(from: request)
+
+        let response = try await client.execute(asyncHTTPClientRequest, deadline: .now() + .seconds(60))
+        let body = try await response.body.collect(upTo: 100 * 1024 * 1024) // 100 MB max
+
+		let data = Data(buffer: body)
+        let httpResponse = HTTPResponse(
+            statusCode: Int(response.status.code),
+            headers: convertHeaders(response.headers)
+        )
+        
+        return (data, httpResponse)
+    }
+    
+    /// Fetches a byte stream for a given HTTP request
+    /// - Parameter request: The HTTP request to perform
+    /// - Returns: A tuple containing the byte stream and HTTP response
+    public func bytes(for request: HTTPRequest) async throws -> (HTTPByteStream, HTTPResponse) {
+        let asyncHTTPClientRequest = try createAsyncHTTPClientRequest(from: request)
+
+        let response = try await client.execute(asyncHTTPClientRequest, deadline: .now() + .seconds(60))
+        let httpResponse = HTTPResponse(
+            statusCode: Int(response.status.code),
+            headers: convertHeaders(response.headers)
+        )
+        
+        let stream = AsyncThrowingStream<String, Error> { continuation in
+            Task {
+                do {
+                    for try await byteBuffer in response.body {
+                        if let string = byteBuffer.getString(at: 0, length: byteBuffer.readableBytes) {
+                            let lines = string.split(separator: "\n", omittingEmptySubsequences: false)
+                            for line in lines {
+                                continuation.yield(String(line))
+                            }
+                        }
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+        
+        return (.lines(stream), httpResponse)
+    }
+    
+    /// Converts our HTTPRequest to AsyncHTTPClient's Request
+    /// - Parameter request: Our HTTPRequest
+    /// - Returns: AsyncHTTPClient Request
+    private func createAsyncHTTPClientRequest(from request: HTTPRequest) throws -> HTTPClientRequest {
+        var asyncHTTPClientRequest = HTTPClientRequest(url: request.url.absoluteString)
+        asyncHTTPClientRequest.method = NIOHTTP1.HTTPMethod(rawValue: request.method.rawValue)
+
+        // Add headers
+        for (key, value) in request.headers {
+            asyncHTTPClientRequest.headers.add(name: key, value: value)
+        }
+        
+        // Add body if present
+        if let body = request.body {
+            asyncHTTPClientRequest.body = .bytes(body)
+        }
+        
+        return asyncHTTPClientRequest
+    }
+    
+    /// Converts NIOHTTP1 headers to a dictionary
+    /// - Parameter headers: NIOHTTP1 HTTPHeaders
+    /// - Returns: Dictionary of header name-value pairs
+    private func convertHeaders(_ headers: HTTPHeaders) -> [String: String] {
+        var result = [String: String]()
+        for header in headers {
+            result[header.name] = header.value
+        }
+        return result
+    }
+    
+    /// Properly shutdown the HTTP client
+    public func shutdown() {
+        try? client.shutdown().wait()
+    }
+    
+    deinit {
+        shutdown()
+    }
+} 

--- a/Sources/OpenAI/Private/Networking/Endpoint.swift
+++ b/Sources/OpenAI/Private/Networking/Endpoint.swift
@@ -6,10 +6,13 @@
 //
 
 import Foundation
+#if os(Linux)
+import FoundationNetworking
+#endif
 
 // MARK: - HTTPMethod
 
-enum HTTPMethod: String {
+public enum HTTPMethod: String {
   case post = "POST"
   case get = "GET"
   case delete = "DELETE"

--- a/Sources/OpenAI/Private/Networking/HTTPClient.swift
+++ b/Sources/OpenAI/Private/Networking/HTTPClient.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Protocol that abstracts HTTP client functionality
+public protocol HTTPClient {
+  /// Fetches data for a given HTTP request
+  /// - Parameter request: The HTTP request to perform
+  /// - Returns: A tuple containing the data and HTTP response
+  func data(for request: HTTPRequest) async throws -> (Data, HTTPResponse)
+
+  /// Fetches a byte stream for a given HTTP request
+  /// - Parameter request: The HTTP request to perform
+  /// - Returns: A tuple containing the byte stream and HTTP response
+  func bytes(for request: HTTPRequest) async throws -> (HTTPByteStream, HTTPResponse)
+}
+
+/// Represents an HTTP request with platform-agnostic properties
+public struct HTTPRequest {
+  /// The URL for the request
+  var url: URL
+  /// The HTTP method for the request
+  var method: HTTPMethod
+  /// The HTTP headers for the request
+  var headers: [String: String]
+  /// The body of the request, if any
+  var body: Data?
+
+  public init(url: URL, method: HTTPMethod, headers: [String: String], body: Data? = nil) {
+    self.url = url
+    self.method = method
+    self.headers = headers
+    self.body = body
+  }
+}
+
+/// Represents an HTTP response with platform-agnostic properties
+public struct HTTPResponse {
+  /// The HTTP status code of the response
+  var statusCode: Int
+  /// The HTTP headers in the response
+  var headers: [String: String]
+
+  public init(statusCode: Int, headers: [String: String]) {
+    self.statusCode = statusCode
+    self.headers = headers
+  }
+}
+
+/// Represents a stream of bytes or lines from an HTTP response
+public enum HTTPByteStream {
+  /// A stream of bytes
+  case bytes(AsyncThrowingStream<UInt8, Error>)
+  /// A stream of lines (strings)
+  case lines(AsyncThrowingStream<String, Error>)
+}

--- a/Sources/OpenAI/Private/Networking/URLSessionHTTPClientAdapter.swift
+++ b/Sources/OpenAI/Private/Networking/URLSessionHTTPClientAdapter.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Adapter that implements HTTPClient protocol using URLSession
+public class URLSessionHTTPClientAdapter: HTTPClient {
+
+    private let urlSession: URLSession
+
+    /// Initializes a new URLSessionHTTPClientAdapter with the provided URLSession
+    /// - Parameter urlSession: The URLSession instance to use. Defaults to `URLSession.shared`.
+    public init(urlSession: URLSession = .shared) {
+        self.urlSession = urlSession
+    }
+
+    /// Fetches data for a given HTTP request
+    /// - Parameter request: The HTTP request to perform
+    /// - Returns: A tuple containing the data and HTTP response
+    public func data(for request: HTTPRequest) async throws -> (Data, HTTPResponse) {
+        let urlRequest = try createURLRequest(from: request)
+        
+        let (data, urlResponse) = try await urlSession.data(for: urlRequest)
+        
+        guard let httpURLResponse = urlResponse as? HTTPURLResponse else {
+            throw URLError(.badServerResponse) // Or a custom error
+        }
+        
+        let response = HTTPResponse(
+            statusCode: httpURLResponse.statusCode,
+            headers: convertHeaders(httpURLResponse.allHeaderFields)
+        )
+        
+        return (data, response)
+    }
+
+    /// Fetches a byte stream for a given HTTP request
+    /// - Parameter request: The HTTP request to perform
+    /// - Returns: A tuple containing the byte stream and HTTP response
+    public func bytes(for request: HTTPRequest) async throws -> (HTTPByteStream, HTTPResponse) {
+        let urlRequest = try createURLRequest(from: request)
+        
+        let (asyncBytes, urlResponse) = try await urlSession.bytes(for: urlRequest)
+        
+        guard let httpURLResponse = urlResponse as? HTTPURLResponse else {
+            throw URLError(.badServerResponse) // Or a custom error
+        }
+        
+        let response = HTTPResponse(
+            statusCode: httpURLResponse.statusCode,
+            headers: convertHeaders(httpURLResponse.allHeaderFields)
+        )
+        
+        let stream = AsyncThrowingStream<String, Error> { continuation in
+            Task {
+                do {
+                    for try await line in asyncBytes.lines {
+                        continuation.yield(line)
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+        
+        return (.lines(stream), response)
+    }
+
+    /// Converts our HTTPRequest to URLRequest
+    /// - Parameter request: Our HTTPRequest
+    /// - Returns: URLRequest
+    private func createURLRequest(from request: HTTPRequest) throws -> URLRequest {
+        var urlRequest = URLRequest(url: request.url)
+        urlRequest.httpMethod = request.method.rawValue
+        
+        for (key, value) in request.headers {
+            urlRequest.setValue(value, forHTTPHeaderField: key)
+        }
+        
+        urlRequest.httpBody = request.body
+        
+        return urlRequest
+    }
+
+    /// Converts HTTPURLResponse headers to a dictionary [String: String]
+    /// - Parameter headers: The headers from HTTPURLResponse (i.e. `allHeaderFields`)
+    /// - Returns: Dictionary of header name-value pairs
+    private func convertHeaders(_ headers: [AnyHashable: Any]) -> [String: String] {
+        var result = [String: String]()
+        for (key, value) in headers {
+            if let keyString = key as? String, let valueString = value as? String {
+                result[keyString] = valueString
+            }
+        }
+        return result
+    }
+}

--- a/Sources/OpenAI/Public/Service/DefaultOpenAIService.swift
+++ b/Sources/OpenAI/Public/Service/DefaultOpenAIService.swift
@@ -16,11 +16,10 @@ struct DefaultOpenAIService: OpenAIService {
     proxyPath: String? = nil,
     overrideVersion: String? = nil,
     extraHeaders: [String: String]? = nil,
-    configuration: URLSessionConfiguration,
     decoder: JSONDecoder = .init(),
     debugEnabled: Bool)
   {
-    session = URLSession(configuration: configuration)
+    self.httpClient = AsyncHTTPClientAdapter.createDefault()
     self.decoder = decoder
     self.apiKey = .bearer(apiKey)
     self.organizationID = organizationID
@@ -32,7 +31,7 @@ struct DefaultOpenAIService: OpenAIService {
     self.debugEnabled = debugEnabled
   }
 
-  let session: URLSession
+  let httpClient: HTTPClient
   let decoder: JSONDecoder
   let openAIEnvironment: OpenAIEnvironment
 

--- a/Sources/OpenAI/Public/Service/DefaultOpenAIService.swift
+++ b/Sources/OpenAI/Public/Service/DefaultOpenAIService.swift
@@ -16,10 +16,11 @@ struct DefaultOpenAIService: OpenAIService {
     proxyPath: String? = nil,
     overrideVersion: String? = nil,
     extraHeaders: [String: String]? = nil,
+    httpClient: HTTPClient,
     decoder: JSONDecoder = .init(),
     debugEnabled: Bool)
   {
-    self.httpClient = AsyncHTTPClientAdapter.createDefault()
+    self.httpClient = httpClient
     self.decoder = decoder
     self.apiKey = .bearer(apiKey)
     self.organizationID = organizationID

--- a/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
+++ b/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
@@ -14,21 +14,24 @@ public class OpenAIServiceFactory {
   /// - Parameters:
   ///   - apiKey: The API key required for authentication.
   ///   - organizationID: The optional organization ID for multi-tenancy (default is `nil`).
-  ///   - configuration: The URL session configuration to be used for network calls (default is `.default`).
   ///   - decoder: The JSON decoder to be used for parsing API responses (default is `JSONDecoder.init()`).
+  ///   - httpClient: The HTTPClient to be used for network calls. Defaults to `AsyncHTTPClientAdapter.createDefault()`
   ///   - debugEnabled: If `true` service prints event on DEBUG builds, default to `false`.
-
+  ///
   /// - Returns: A fully configured object conforming to `OpenAIService`.
   public static func service(
     apiKey: String,
     organizationID: String? = nil,
     decoder: JSONDecoder = .init(),
+    httpClient: HTTPClient? = nil,
     debugEnabled: Bool = false)
     -> OpenAIService
   {
-    DefaultOpenAIService(
+    let client = httpClient ?? AsyncHTTPClientAdapter.createDefault()
+    return DefaultOpenAIService(
       apiKey: apiKey,
       organizationID: organizationID,
+      httpClient: client,
       decoder: decoder,
       debugEnabled: debugEnabled)
   }
@@ -40,17 +43,21 @@ public class OpenAIServiceFactory {
   /// - Parameters:
   ///   - azureConfiguration: The AzureOpenAIConfiguration.
   ///   - decoder: The JSON decoder to be used for parsing API responses (default is `JSONDecoder.init()`).
+  ///   - httpClient: The HTTPClient to be used for network calls. Defaults to `AsyncHTTPClientAdapter.createDefault()`
   ///   - debugEnabled: If `true` service prints event on DEBUG builds, default to `false`.
   ///
   /// - Returns: A fully configured object conforming to `OpenAIService`.
   public static func service(
     azureConfiguration: AzureOpenAIConfiguration,
     decoder: JSONDecoder = .init(),
+    httpClient: HTTPClient? = nil,
     debugEnabled: Bool = false)
     -> OpenAIService
   {
-    DefaultOpenAIAzureService(
+    let client = httpClient ?? AsyncHTTPClientAdapter.createDefault()
+    return DefaultOpenAIAzureService(
       azureConfiguration: azureConfiguration,
+      httpClient: client,
       decoder: decoder,
       debugEnabled: debugEnabled)
   }
@@ -101,18 +108,22 @@ public class OpenAIServiceFactory {
   /// - Parameters:
   ///   - apiKey: The optional API key required for authentication.
   ///   - baseURL: The local host URL. defaults to  "http://localhost:11434"
+  ///   - httpClient: The HTTPClient to be used for network calls. Defaults to `AsyncHTTPClientAdapter.createDefault()`
   ///   - debugEnabled: If `true` service prints event on DEBUG builds, default to `false`.
   ///
   /// - Returns: A fully configured object conforming to `OpenAIService`.
   public static func service(
     apiKey: Authorization = .apiKey(""),
     baseURL: String,
+    httpClient: HTTPClient? = nil,
     debugEnabled: Bool = false)
     -> OpenAIService
   {
-    LocalModelService(
+    let client = httpClient ?? AsyncHTTPClientAdapter.createDefault()
+    return LocalModelService(
       apiKey: apiKey,
       baseURL: baseURL,
+      httpClient: client,
       debugEnabled: debugEnabled)
   }
 
@@ -128,6 +139,7 @@ public class OpenAIServiceFactory {
   ///   - proxyPath: The proxy path e.g `openai`
   ///   - overrideVersion: The API version. defaults to `v1`
   ///   - extraHeaders: Additional headers needed for the request. Do not provide API key in these headers.
+  ///   - httpClient: The HTTPClient to be used for network calls. Defaults to `AsyncHTTPClientAdapter.createDefault()`
   ///   - debugEnabled: If `true` service prints event on DEBUG builds, default to `false`.
   ///
   /// - Returns: A fully configured object conforming to `OpenAIService`.
@@ -137,15 +149,18 @@ public class OpenAIServiceFactory {
     proxyPath: String? = nil,
     overrideVersion: String? = nil,
     extraHeaders: [String: String]? = nil,
+    httpClient: HTTPClient? = nil,
     debugEnabled: Bool = false)
     -> OpenAIService
   {
-    DefaultOpenAIService(
+    let client = httpClient ?? AsyncHTTPClientAdapter.createDefault()
+    return DefaultOpenAIService(
       apiKey: apiKey,
       baseURL: overrideBaseURL,
       proxyPath: proxyPath,
       overrideVersion: overrideVersion,
       extraHeaders: extraHeaders,
+      httpClient: client,
       debugEnabled: debugEnabled)
   }
 }

--- a/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
+++ b/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
@@ -22,7 +22,6 @@ public class OpenAIServiceFactory {
   public static func service(
     apiKey: String,
     organizationID: String? = nil,
-    configuration: URLSessionConfiguration = .default,
     decoder: JSONDecoder = .init(),
     debugEnabled: Bool = false)
     -> OpenAIService
@@ -30,7 +29,6 @@ public class OpenAIServiceFactory {
     DefaultOpenAIService(
       apiKey: apiKey,
       organizationID: organizationID,
-      configuration: configuration,
       decoder: decoder,
       debugEnabled: debugEnabled)
   }
@@ -41,25 +39,23 @@ public class OpenAIServiceFactory {
   ///
   /// - Parameters:
   ///   - azureConfiguration: The AzureOpenAIConfiguration.
-  ///   - urlSessionConfiguration: The URL session configuration to be used for network calls (default is `.default`).
   ///   - decoder: The JSON decoder to be used for parsing API responses (default is `JSONDecoder.init()`).
   ///   - debugEnabled: If `true` service prints event on DEBUG builds, default to `false`.
   ///
   /// - Returns: A fully configured object conforming to `OpenAIService`.
   public static func service(
     azureConfiguration: AzureOpenAIConfiguration,
-    urlSessionConfiguration: URLSessionConfiguration = .default,
     decoder: JSONDecoder = .init(),
     debugEnabled: Bool = false)
     -> OpenAIService
   {
     DefaultOpenAIAzureService(
       azureConfiguration: azureConfiguration,
-      urlSessionConfiguration: urlSessionConfiguration,
       decoder: decoder,
       debugEnabled: debugEnabled)
   }
 
+  #if !os(Linux)
   // MARK: AIProxy
 
   /// Creates and returns an instance of `OpenAIService` for use with aiproxy.pro
@@ -93,6 +89,7 @@ public class OpenAIServiceFactory {
       clientID: aiproxyClientID,
       debugEnabled: debugEnabled)
   }
+  #endif
 
   // MARK: Custom URL
 
@@ -137,7 +134,6 @@ public class OpenAIServiceFactory {
   public static func service(
     apiKey: String,
     overrideBaseURL: String,
-    configuration: URLSessionConfiguration = .default,
     proxyPath: String? = nil,
     overrideVersion: String? = nil,
     extraHeaders: [String: String]? = nil,
@@ -150,7 +146,6 @@ public class OpenAIServiceFactory {
       proxyPath: proxyPath,
       overrideVersion: overrideVersion,
       extraHeaders: extraHeaders,
-      configuration: configuration,
       debugEnabled: debugEnabled)
   }
 }


### PR DESCRIPTION
This PR adds support for Linux, as requested in #89. It does so by:
- Creating a new networking layer using Apple's [AsyncHTTPClient](https://github.com/swift-server/async-http-client) library. This is considered to be the gold-standard for Swift on Linux, and is also a solid networking layer for iOS/macOS apps, and fixes the many bugs that URLSession has on Linux platforms.
- To ensure compatibility on Apple platforms, I've added a URLSessionHTTPClientAdapter which makes network requests through URLSession.
- When creating a new service, there is a configurable parameter for users to specify their preferred HTTPClient. This allows maximum flexibility for end-users, in case they have a preference for networking stack.

> [!NOTE]
>These changes are not applied to any of the code related to AIProxy. I've left everything alone there as best as I can, and simply do not compile any AIProxy code on Linux, since AIProxy does not make much sense to use in a server environment where API requests are already protected.

Please let me know what you think, happy to make any changes you request. Would love to get this merged in so I can start using SwiftOpenAI in my server-side app!