### PR TITLE
Fix SwiftFormat lint issue in TextConfiguration

### DIFF
--- a/Sources/OpenAI/Public/Shared/TextConfiguration.swift
+++ b/Sources/OpenAI/Public/Shared/TextConfiguration.swift
@@ -57,7 +57,7 @@ public enum FormatType: Codable {
     case .text:
       try container.encode("text", forKey: .type)
 
-    case let .jsonSchema(schema, name):
+    case .jsonSchema(let schema, let name):
       try container.encode("json_schema", forKey: .type)
       try container.encode(name ?? "schema_response", forKey: .name)
       try container.encode(schema, forKey: .schema)


### PR DESCRIPTION
- Update pattern matching syntax to hoist let keywords individually
- Change from `case let .jsonSchema(schema, name):` to `case .jsonSchema(let schema, let name):`
- Ensures compliance with SwiftFormat rules

🤖 Generated with [Claude Code](https://claude.ai/code)