### PR TITLE
Add extraBody support

### DIFF
--- a/Sources/OpenAI/Public/Parameters/Chat/ChatCompletionParameters.swift
+++ b/Sources/OpenAI/Public/Parameters/Chat/ChatCompletionParameters.swift
@@ -39,7 +39,8 @@ public struct ChatCompletionParameters: Encodable {
     temperature: Double? = nil,
     topProbability: Double? = nil,
     user: String? = nil,
-    streamOptions: StreamOptions? = nil)
+    streamOptions: StreamOptions? = nil,
+    extraBody: [String: Any]? = nil)
   {
     self.messages = messages
     self.model = model.value
@@ -69,6 +70,7 @@ public struct ChatCompletionParameters: Encodable {
     topP = topProbability
     self.user = user
     self.streamOptions = streamOptions
+    self.extraBody = extraBody
   }
 
   public struct Message: Encodable {
@@ -488,6 +490,9 @@ public struct ChatCompletionParameters: Encodable {
   /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
   /// [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).
   public var user: String?
+  /// Additional parameters that are not part of the standard OpenAI API but may be supported by the underlying service.
+  /// This allows access to experimental or provider-specific features.
+  public var extraBody: [String: Any]?
 
   enum CodingKeys: String, CodingKey {
     case messages


### PR DESCRIPTION
Qwen3 model support [Hybrid Thinking Modes](https://qwenlm.github.io/blog/qwen3/#:~:text=Hybrid%20Thinking%20Modes,support%20two%20modes%3A), opensource  model is enable Thinking mode by default which is not suitable for  time sensitive task (Translation, etc)
We can add extra boy param to disable Thinking mode, like ollama [Example using Ollama’s chat API with thinking enabled](https://ollama.com/blog/thinking#:~:text=Example%20using%20Ollama%E2%80%99s%20chat%20API%20with%20thinking%20enabled)

OpenAI Python SDK also support [this feature](https://github.com/openai/openai-python/blob/0673da62f2f2476a3e5791122e75ec0cbfd03442/src/openai/resources/chat/completions/messages.py#L54)