### PR TITLE
Api error details

### DIFF
--- a/Sources/OpenAI/Public/Service/OpenAIService.swift
+++ b/Sources/OpenAI/Public/Service/OpenAIService.swift
@@ -1028,7 +1028,7 @@ extension OpenAIService {
       var errorMessage = "status code \(response.statusCode)"
       do {
         let error = try decoder.decode(OpenAIErrorResponse.self, from: data)
-        errorMessage += " \(error.error.message ?? "NO ERROR MESSAGE PROVIDED")"
+        errorMessage = error.error.message ?? "NO ERROR MESSAGE PROVIDED"
       } catch {
         // If decoding fails, keep the original error message with status code
       }
@@ -1076,7 +1076,7 @@ extension OpenAIService {
       var errorMessage = "Status code \(response.statusCode)"
       do {
         let errorResponse = try decoder.decode(OpenAIErrorResponse.self, from: data)
-        errorMessage += " \(errorResponse.error.message ?? "NO ERROR MESSAGE PROVIDED")"
+        errorMessage = errorResponse.error.message ?? "NO ERROR MESSAGE PROVIDED"
       } catch {
         if let errorString = String(data: data, encoding: .utf8), !errorString.isEmpty {
           errorMessage += " - \(errorString)"
@@ -1122,7 +1122,7 @@ extension OpenAIService {
       var errorMessage = "status code \(response.statusCode)"
       do {
         let error = try decoder.decode(OpenAIErrorResponse.self, from: data)
-        errorMessage += " \(error.error.message ?? "NO ERROR MESSAGE PROVIDED")"
+        errorMessage = error.error.message ?? "NO ERROR MESSAGE PROVIDED"
       } catch {
         // If decoding fails, keep the original error message with status code
       }
@@ -1193,7 +1193,7 @@ extension OpenAIService {
         // as error responses are regular JSON, not streaming data
         let (errorData, _) = try await httpClient.data(for: httpRequest)
         let error = try decoder.decode(OpenAIErrorResponse.self, from: errorData)
-        errorMessage += " \(error.error.message ?? "NO ERROR MESSAGE PROVIDED")"
+        errorMessage = error.error.message ?? "NO ERROR MESSAGE PROVIDED"
       } catch {
         // If decoding fails, keep the original error message with status code
       }
@@ -1291,7 +1291,7 @@ extension OpenAIService {
         // as error responses are regular JSON, not streaming data
         let (errorData, _) = try await httpClient.data(for: httpRequest)
         let error = try decoder.decode(OpenAIErrorResponse.self, from: errorData)
-        errorMessage += " \(error.error.message ?? "NO ERROR MESSAGE PROVIDED")"
+        errorMessage = error.error.message ?? "NO ERROR MESSAGE PROVIDED"
       } catch {
         // If decoding fails, keep the original error message with status code
       }

--- a/Sources/OpenAI/Public/Service/OpenAIService.swift
+++ b/Sources/OpenAI/Public/Service/OpenAIService.swift
@@ -1030,8 +1030,7 @@ extension OpenAIService {
         let error = try decoder.decode(OpenAIErrorResponse.self, from: data)
         errorMessage += " \(error.error.message ?? "NO ERROR MESSAGE PROVIDED")"
       } catch {
-        // If decoding fails, proceed with a general error message
-        errorMessage = "status code \(response.statusCode)"
+        // If decoding fails, keep the original error message with status code
       }
       throw APIError.responseUnsuccessful(
         description: errorMessage,
@@ -1125,8 +1124,7 @@ extension OpenAIService {
         let error = try decoder.decode(OpenAIErrorResponse.self, from: data)
         errorMessage += " \(error.error.message ?? "NO ERROR MESSAGE PROVIDED")"
       } catch {
-        // If decoding fails, proceed with a general error message
-        errorMessage = "status code \(response.statusCode)"
+        // If decoding fails, keep the original error message with status code
       }
       throw APIError.responseUnsuccessful(
         description: errorMessage,
@@ -1189,8 +1187,18 @@ extension OpenAIService {
     }
 
     guard response.statusCode == 200 else {
+      var errorMessage = "status code \(response.statusCode)"
+      do {
+        // For error responses, we need to get the raw data instead of using the stream
+        // as error responses are regular JSON, not streaming data
+        let (errorData, _) = try await httpClient.data(for: httpRequest)
+        let error = try decoder.decode(OpenAIErrorResponse.self, from: errorData)
+        errorMessage += " \(error.error.message ?? "NO ERROR MESSAGE PROVIDED")"
+      } catch {
+        // If decoding fails, keep the original error message with status code
+      }
       throw APIError.responseUnsuccessful(
-        description: "status code \(response.statusCode)",
+        description: errorMessage,
         statusCode: response.statusCode)
     }
 
@@ -1277,8 +1285,18 @@ extension OpenAIService {
     printHTTPResponse(response)
 
     guard response.statusCode == 200 else {
+      var errorMessage = "status code \(response.statusCode)"
+      do {
+        // For error responses, we need to get the raw data instead of using the stream
+        // as error responses are regular JSON, not streaming data
+        let (errorData, _) = try await httpClient.data(for: httpRequest)
+        let error = try decoder.decode(OpenAIErrorResponse.self, from: errorData)
+        errorMessage += " \(error.error.message ?? "NO ERROR MESSAGE PROVIDED")"
+      } catch {
+        // If decoding fails, keep the original error message with status code
+      }
       throw APIError.responseUnsuccessful(
-        description: "status code \(response.statusCode)",
+        description: errorMessage,
         statusCode: response.statusCode)
     }
 


### PR DESCRIPTION
### Problem

The streaming methods (fetchStream and fetchAssistantStreamEvents) don't decode OpenAI error responses, only returning generic "status code X" messages instead of detailed error information.

### Solution

Apply the same OpenAI error decoding logic from the working fetch method to both streaming methods.

### Note

This PRs also modifies the `errorMessage` to keep the original error message from API server, giving application full control over how to construct the final error message. Rationale: I think at library-level, we should not modify the error message from remote API server. This would make it very difficult at the app-level  to offer good error reporting UX.