### PR TITLE
Do not throw error for unknown event types

### DIFF
--- a/Sources/OpenAI/Public/ResponseModels/Response/ResponseStreamEvent.swift
+++ b/Sources/OpenAI/Public/ResponseModels/Response/ResponseStreamEvent.swift
@@ -142,6 +142,9 @@ public enum ResponseStreamEvent: Decodable {
 
   /// Emitted when an error occurs
   case error(ErrorEvent)
+    
+  /// For unknown event type
+  case unknownEventType(String)
 
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -237,10 +240,7 @@ public enum ResponseStreamEvent: Decodable {
     case "error":
       self = try .error(ErrorEvent(from: decoder))
     default:
-      throw DecodingError.dataCorruptedError(
-        forKey: .type,
-        in: container,
-        debugDescription: "Unknown event type: \(type)")
+      self = .unknownEventType(type)
     }
   }
 

--- a/Tests/OpenAITests/ResponseStreamEventTests.swift
+++ b/Tests/OpenAITests/ResponseStreamEventTests.swift
@@ -720,10 +720,8 @@ final class ResponseStreamEventTests: XCTestCase {
 
     do {
       _ = try decoder.decode(ResponseStreamEvent.self, from: json.data(using: .utf8)!)
-      XCTFail("Should have thrown an error for unknown event type")
     } catch {
-      // Expected error
-      XCTAssertTrue(error is DecodingError)
+      XCTFail("Should have thrown an error for unknown event type")
     }
   }
 }


### PR DESCRIPTION
### Overview

Currently, SwiftOpenAI throws a `DecodingError.dataCorruptedError` for an unknown response stream event. This is not a good behavior IMO. For example, currently there are new events from OpenAI that are not handled in the library. It's harmless (citation related) but it would break the happy path flow at the app-level.

I think the better solution is to return a `unknownEventType` response instead and let the app decide how to handle it.