### PR TITLE
Decode error responses for OpenRouter

### DIFF
--- a/Sources/OpenAI/Public/ResponseModels/OpenAIErrorResponse.swift
+++ b/Sources/OpenAI/Public/ResponseModels/OpenAIErrorResponse.swift
@@ -24,5 +24,26 @@ public struct OpenAIErrorResponse: Decodable {
     public let type: String?
     public let param: String?
     public let code: String?
+
+    enum CodingKeys: String, CodingKey {
+      case message, type, param, code
+    }
+
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      message = try container.decodeIfPresent(String.self, forKey: .message)
+      type = try container.decodeIfPresent(String.self, forKey: .type)
+      param = try container.decodeIfPresent(String.self, forKey: .param)
+
+      // Some OpenAI-compatible providers (e.g. OpenRouter) provide literal response status codes in the "code" field (e.g., 403)
+      // Try decoding "code" first as an Int, then fallback to a String
+      if let intCode = try? container.decodeIfPresent(Int.self, forKey: .code) {
+        code = String(intCode)
+      } else if let stringCode = try? container.decodeIfPresent(String.self, forKey: .code) {
+        code = stringCode
+      } else {
+        code = nil
+      }
+    }
   }
 }


### PR DESCRIPTION
Some OpenAI-compatible providers (e.g., OpenRouter) provide literal response status codes in the "code" field (e.g., 403). To support these non-compatible error codes, we will now attempt to decode "code" first as an Int, then fall back to a String.