### PR TITLE
Fixing key path value type 'String' cannot be converted to contextual type 'String?'

### DIFF
--- a/Sources/OpenAI/Public/Parameters/Conversations/CreateConversationItemsParameter.swift
+++ b/Sources/OpenAI/Public/Parameters/Conversations/CreateConversationItemsParameter.swift
@@ -17,7 +17,7 @@ public struct CreateConversationItemsParameter: Codable {
     include: [ResponseInclude]? = nil)
   {
     self.items = items
-    self.include = include?.compactMap(\.rawValue)
+    self.include = include?.map(\.rawValue)
   }
 
   /// The items to add to the conversation. You may add up to 20 items at a time.

--- a/Sources/OpenAI/Public/Parameters/Conversations/GetConversationItemParameter.swift
+++ b/Sources/OpenAI/Public/Parameters/Conversations/GetConversationItemParameter.swift
@@ -15,7 +15,7 @@ public struct GetConversationItemParameter: Codable {
   public init(
     include: [ResponseInclude]? = nil)
   {
-    self.include = include?.compactMap(\.rawValue)
+    self.include = include?.map(\.rawValue)
   }
 
   /// Additional fields to include in the response.

--- a/Sources/OpenAI/Public/Parameters/Conversations/GetConversationItemsParameter.swift
+++ b/Sources/OpenAI/Public/Parameters/Conversations/GetConversationItemsParameter.swift
@@ -19,7 +19,7 @@ public struct GetConversationItemsParameter: Codable {
     order: String? = nil)
   {
     self.after = after
-    self.include = include?.compactMap(\.rawValue)
+    self.include = include?.map(\.rawValue)
     self.limit = limit
     self.order = order
   }

--- a/Sources/OpenAI/Public/Parameters/Response/GetInputItemsParameter.swift
+++ b/Sources/OpenAI/Public/Parameters/Response/GetInputItemsParameter.swift
@@ -19,7 +19,7 @@ public struct GetInputItemsParameter: Codable {
     order: String? = nil)
   {
     self.after = after
-    self.include = include?.compactMap(\.rawValue)
+    self.include = include?.map(\.rawValue)
     self.limit = limit
     self.order = order
   }

--- a/Sources/OpenAI/Public/Parameters/Response/GetResponseParameter.swift
+++ b/Sources/OpenAI/Public/Parameters/Response/GetResponseParameter.swift
@@ -18,7 +18,7 @@ public struct GetResponseParameter: Codable {
     startingAfter: Int? = nil,
     stream: Bool? = nil)
   {
-    self.include = include?.compactMap(\.rawValue)
+    self.include = include?.map(\.rawValue)
     self.includeObfuscation = includeObfuscation
     self.startingAfter = startingAfter
     self.stream = stream

--- a/Sources/OpenAI/Public/Parameters/Response/ModelResponseParameter.swift
+++ b/Sources/OpenAI/Public/Parameters/Response/ModelResponseParameter.swift
@@ -45,7 +45,7 @@ public struct ModelResponseParameter: Codable {
     self.conversation = conversation
     self.input = input
     self.model = model.value
-    self.include = include?.compactMap(\.rawValue)
+    self.include = include?.map(\.rawValue)
     self.instructions = instructions
     self.maxOutputTokens = maxOutputTokens
     self.maxToolCalls = maxToolCalls


### PR DESCRIPTION
I'm not sure why this compiles fine locally on macOS and on the Linux CI tests, but when I pushed version 4.3+ (all the way to 4.3.4) to my Heroku server it failed to compile due to this error. I ran these changes locally and on my server to test out the fix, and it should work fine now.