### PR TITLE
Fix Azure OpenAI base URL construction

### DIFF
--- a/Sources/OpenAI/Azure/DefaultOpenAIAzureService.swift
+++ b/Sources/OpenAI/Azure/DefaultOpenAIAzureService.swift
@@ -22,7 +22,7 @@ public final class DefaultOpenAIAzureService: OpenAIService {
     self.httpClient = httpClient
     self.decoder = decoder
     openAIEnvironment = OpenAIEnvironment(
-      baseURL: "https://\(azureConfiguration.resourceName)/openai.azure.com",
+      baseURL: "https://\(azureConfiguration.resourceName).openai.azure.com",
       proxyPath: nil,
       version: nil)
     apiKey = azureConfiguration.openAIAPIKey


### PR DESCRIPTION
## Summary
- Fixed incorrect Azure OpenAI endpoint URL construction
- Changed separator from forward slash (`/`) to dot (`.`) in base URL

## Problem
The base URL was using:
```
https://{resourceName}/openai.azure.com
```

This resulted in DNS resolution failures because it creates a malformed URL where `{resourceName}` is treated as the entire hostname, and `/openai.azure.com` is treated as a path.

## Solution
Changed to the correct Azure OpenAI format:
```
https://{resourceName}.openai.azure.com
```

This properly forms a subdomain structure that resolves correctly.

## Reference
- [Azure OpenAI API Reference Documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference)

## Test plan
- [ ] Verify Azure OpenAI chat completion requests now resolve correctly
- [ ] Test with actual Azure OpenAI resource to confirm endpoint connectivity
- [ ] Validate that the full URL construction follows the pattern: `https://{resourceName}.openai.azure.com/openai/deployments/{deployment-id}/...`

Fixes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)