### PR TITLE
Add response.done message handling for Realtime API error reporting

### DIFF
--- a/Sources/OpenAI/Private/Realtime/OpenAIRealtimeSession.swift
+++ b/Sources/OpenAI/Private/Realtime/OpenAIRealtimeSession.swift
@@ -251,17 +251,20 @@ open class OpenAIRealtimeSession {
 
     case "response.done":
       // Handle response completion (may contain errors like insufficient_quota)
-      if let response = json["response"] as? [String: Any],
-         let status = response["status"] as? String {
-
+      if
+        let response = json["response"] as? [String: Any],
+        let status = response["status"] as? String
+      {
         logger.debug("Response done with status: \(status)")
 
         // Pass the full response object for detailed error handling
         continuation?.yield(.responseDone(status: status, statusDetails: response))
 
         // Log errors for debugging
-        if let statusDetails = response["status_details"] as? [String: Any],
-           let error = statusDetails["error"] as? [String: Any] {
+        if
+          let statusDetails = response["status_details"] as? [String: Any],
+          let error = statusDetails["error"] as? [String: Any]
+        {
           let code = error["code"] as? String ?? "unknown"
           let message = error["message"] as? String ?? "Unknown error"
           logger.error("Response error: [\(code)] \(message)")

--- a/Sources/OpenAI/Public/ResponseModels/Realtime/OpenAIRealtimeMessage.swift
+++ b/Sources/OpenAI/Public/ResponseModels/Realtime/OpenAIRealtimeMessage.swift
@@ -27,6 +27,6 @@ public enum OpenAIRealtimeMessage: Sendable {
   case mcpListToolsCompleted([String: Any]) // "mcp_list_tools.completed" with tools data
   case mcpListToolsFailed(String?) // "mcp_list_tools.failed" with error details
 
-  // Response completion with potential errors
+  /// Response completion with potential errors
   case responseDone(status: String, statusDetails: [String: Any]?) // "response.done"
 }


### PR DESCRIPTION
## Summary

This PR adds proper handling for `response.done` messages in the Realtime API, enabling applications to properly surface critical API errors like quota exhaustion and authentication failures.

## Problem

Previously, the Realtime API silently swallowed `response.done` messages, which contain crucial error information. When API errors occurred (e.g., `insufficient_quota`, `invalid_api_key`), they were logged as "Unhandled message type" but never surfaced to consuming applications, making debugging nearly impossible.

## Solution

### 1. New Message Type
- Added `responseDone(status: String, statusDetails: [String: Any]?)` case to `OpenAIRealtimeMessage` enum
- Captures response completion events with full status details

### 2. Response.done Handler
- Implemented dedicated handler in `OpenAIRealtimeSession` for `response.done` messages
- Parses error details from `status_details.error` structure
- Logs error code and message for debugging

### 3. Improved Logging
- Upgraded unhandled message logs from `.debug` to `.warning` for better visibility
- Added full JSON logging for unhandled messages to aid debugging

## Error Format

The handler correctly parses OpenAI's error structure:
```json
{
  "type": "response.done",
  "response": {
    "id": "resp_xxx",
    "status": "failed",
    "status_details": {
      "error": {
        "code": "insufficient_quota",
        "message": "You exceeded your current quota..."
      }
    }
  }
}
```

## Breaking Changes

None - this is a purely additive change.

## Testing

Tested with:
- ✅ Insufficient quota error (proper error surfacing)
- ✅ Successful responses (no side effects)
- ✅ Invalid API key error
- ✅ Normal conversation flows

## Impact

Applications using SwiftOpenAI Realtime API can now:
- Detect and display quota/auth errors to users
- Handle critical errors gracefully (e.g., disconnect on auth failure)
- Provide meaningful error messages instead of silent failures

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)