### PR TITLE
feat: add support for gpt-image-1-mini model

### DIFF
--- a/Sources/OpenAI/Public/Parameters/ImageGen/CreateImageEditParameters.swift
+++ b/Sources/OpenAI/Public/Parameters/ImageGen/CreateImageEditParameters.swift
@@ -149,6 +149,7 @@ public struct CreateImageEditParameters: Encodable {
   public enum ModelType: String {
     case dallE2 = "dall-e-2"
     case gptImage1 = "gpt-image-1"
+    case gptImage1Mini = "gpt-image-1-mini"
   }
 
   public enum Quality: String {


### PR DESCRIPTION
### Description
This PR adds support for the `gpt-image-1-mini` model by adding a new case to the `ModelType` enum.

### Related Issue
[Resolves #184](https://github.com/jamesrochabrun/SwiftOpenAI/issues/184#issuecomment-3621687571)

### Changes
- Added `case gptImage1Mini = "gpt-image-1-mini"` to the supported models enum.