### PR TITLE
Fix streaming function call decoding error when 'name' field is missing

### DIFF
--- a/Sources/OpenAI/Public/ResponseModels/Response/ResponseStreamEvent.swift
+++ b/Sources/OpenAI/Public/ResponseModels/Response/ResponseStreamEvent.swift
@@ -607,7 +607,7 @@ public struct FunctionCallArgumentsDoneEvent: Decodable {
   public let type: String
   public let itemId: String
   public let outputIndex: Int
-  public let name: String
+  public let name: String?
   public let arguments: String
   public let sequenceNumber: Int?
 


### PR DESCRIPTION
## Summary

- Make `name` optional in `FunctionCallArgumentsDoneEvent` to fix decoding error when OpenAI API omits this field

Fixes #188

## Problem

When streaming responses with function calls, the decoder fails with:
```
Key 'name' not found: No value associated with key CodingKeys(stringValue: "name", intValue: nil)
```

The OpenAI API doesn't always include the `name` field in `response.function_call_arguments.done` streaming events.

## Solution

Changed `name` from `String` to `String?` in `FunctionCallArgumentsDoneEvent`, aligning with the pattern already used in `ToolCall.FunctionCall`.

## Test plan

- [ ] Run ResponseAPIDemo with a custom function tool
- [ ] Verify streaming function calls complete without decoding errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)