### PR TITLE
Fix InstructionsType decoding for reusable prompts (issue #187)

### DIFF
--- a/Sources/OpenAI/Public/ResponseModels/Response/ResponseModel.swift
+++ b/Sources/OpenAI/Public/ResponseModels/Response/ResponseModel.swift
@@ -54,10 +54,11 @@ public struct ResponseModel: Decodable {
     }
   }
 
-  /// Instructions type - can be a string or an array of strings
+  /// Instructions type - can be a string, an array of strings, or an array of messages (for reusable prompts)
   public enum InstructionsType: Decodable {
     case string(String)
     case array([String])
+    case messages([InputMessage])
 
     public init(from decoder: Decoder) throws {
       let container = try decoder.singleValueContainer()
@@ -66,10 +67,12 @@ public struct ResponseModel: Decodable {
         self = .string(stringValue)
       } else if let arrayValue = try? container.decode([String].self) {
         self = .array(arrayValue)
+      } else if let messagesValue = try? container.decode([InputMessage].self) {
+        self = .messages(messagesValue)
       } else {
         throw DecodingError.dataCorruptedError(
           in: container,
-          debugDescription: "Expected String or [String] for instructions")
+          debugDescription: "Expected String, [String], or [InputMessage] for instructions")
       }
     }
   }


### PR DESCRIPTION
## Summary
- Fixes #187: Decoding error when using reusable prompts with variables
- Added `messages([InputMessage])` case to `InstructionsType` to handle array of message objects returned by the API
- Added 3 tests to cover all `InstructionsType` variants (string, array of strings, array of messages)

## Test plan
- [x] Run `swift test --filter ResponseModelValidationTests` - all 10 tests pass
- [x] `testInstructionsTypeStringDecoding` - verifies string instructions still work
- [x] `testInstructionsTypeArrayOfStringsDecoding` - verifies array of strings still works  
- [x] `testInstructionsTypeMessagesDecoding` - verifies the fix for reusable prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)