### PR TITLE
feat: Add ProxLock Service

### DIFF
--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0DEE5DC12BB40643004894AD /* SwiftOpenAI in Frameworks */ = {isa = PBXBuildFile; productRef = 0DEE5DC02BB40643004894AD /* SwiftOpenAI */; };
 		0DF957842BB53BEF00DD2013 /* ServiceSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF957832BB53BEF00DD2013 /* ServiceSelectionView.swift */; };
 		0DF957862BB543F100DD2013 /* AIProxyIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF957852BB543F100DD2013 /* AIProxyIntroView.swift */; };
+		22BD10FE2F084C8000D238BC /* ProxLockIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BD10FD2F084C8000D238BC /* ProxLockIntroView.swift */; };
 		7B029E372C6893FD0025681A /* ChatStructuredOutputProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B029E362C6893FD0025681A /* ChatStructuredOutputProvider.swift */; };
 		7B029E392C68940D0025681A /* ChatStructuredOutputDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B029E382C68940D0025681A /* ChatStructuredOutputDemoView.swift */; };
 		7B029E3C2C69BE990025681A /* ChatStructuredOutputToolProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B029E3B2C69BE990025681A /* ChatStructuredOutputToolProvider.swift */; };
@@ -95,6 +96,7 @@
 /* Begin PBXFileReference section */
 		0DF957832BB53BEF00DD2013 /* ServiceSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceSelectionView.swift; sourceTree = "<group>"; };
 		0DF957852BB543F100DD2013 /* AIProxyIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProxyIntroView.swift; sourceTree = "<group>"; };
+		22BD10FD2F084C8000D238BC /* ProxLockIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxLockIntroView.swift; sourceTree = "<group>"; };
 		7B029E362C6893FD0025681A /* ChatStructuredOutputProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStructuredOutputProvider.swift; sourceTree = "<group>"; };
 		7B029E382C68940D0025681A /* ChatStructuredOutputDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStructuredOutputDemoView.swift; sourceTree = "<group>"; };
 		7B029E3B2C69BE990025681A /* ChatStructuredOutputToolProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStructuredOutputToolProvider.swift; sourceTree = "<group>"; };
@@ -417,6 +419,7 @@
 				7BBE7E922AFCC9300096A693 /* Vision */,
 				7BA788CE2AE23A48008825D5 /* ApiKeyIntroView.swift */,
 				7B50DD272C2A9A390070A64D /* LocalHostEntryView.swift */,
+				22BD10FD2F084C8000D238BC /* ProxLockIntroView.swift */,
 				0DF957852BB543F100DD2013 /* AIProxyIntroView.swift */,
 				7B436B952AE24A04003CE281 /* OptionsListView.swift */,
 				0DF957832BB53BEF00DD2013 /* ServiceSelectionView.swift */,
@@ -645,6 +648,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7BBE7EA92B02E8E50096A693 /* ChatMessageView.swift in Sources */,
+				22BD10FE2F084C8000D238BC /* ProxLockIntroView.swift in Sources */,
 				7BE802592D2878170080E06A /* ChatPredictedOutputDemoView.swift in Sources */,
 				7B7239AE2AF9FF0000646679 /* ChatFunctionsCallStreamProvider.swift in Sources */,
 				7B436BA12AE25958003CE281 /* ChatProvider.swift in Sources */,

--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample.xcodeproj/xcshareddata/xcschemes/SwiftOpenAIExample.xcscheme
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample.xcodeproj/xcshareddata/xcschemes/SwiftOpenAIExample.xcscheme
@@ -82,6 +82,13 @@
             ReferencedContainer = "container:SwiftOpenAIExample.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "PROXLOCK_DEVICE_CHECK_BYPASS"
+            value = "21015698-3654-44A7-A5C6-28919004C781"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ProxLockIntroView.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ProxLockIntroView.swift
@@ -1,0 +1,66 @@
+//
+//  ProxLockIntroView.swift
+//  SwiftOpenAIExample
+//
+//  Created by Morris Richman on 1/2/2026.
+//
+
+import SwiftOpenAI
+import SwiftUI
+
+struct ProxLockIntroView: View {
+  var body: some View {
+    NavigationStack {
+      VStack {
+        Spacer()
+        VStack(spacing: 24) {
+          TextField("Enter partial key", text: $partialKey)
+          TextField("Enter your association ID", text: $associationID)
+        }
+        .padding()
+        .textFieldStyle(.roundedBorder)
+
+        Text("You receive a partial key and association ID when you configure an app in the ProxLock dashboard")
+          .font(.caption)
+
+        NavigationLink(destination: OptionsListView(
+          openAIService: proxlockService,
+          options: OptionsListView.APIOption.allCases.filter { $0 != .localChat }))
+        {
+          Text("Continue")
+            .padding()
+            .padding(.horizontal, 48)
+            .foregroundColor(.white)
+            .background(
+              Capsule()
+                .foregroundColor(canProceed ? Color(red: 64 / 255, green: 195 / 255, blue: 125 / 255) : .gray.opacity(0.2)))
+        }
+        .disabled(!canProceed)
+        Spacer()
+        Group {
+          Text(
+            "ProxLock keeps your OpenAI API key secure. To configure ProxLock for your project, or to learn more about how it works, please see the docs ") +
+            Text("[here](https://docs.proxlock.dev).")
+        }
+        .font(.caption)
+      }
+      .padding()
+      .navigationTitle("ProxLock Configuration")
+    }
+  }
+
+  @State private var partialKey = ""
+  @State private var associationID = ""
+
+  private var canProceed: Bool {
+    !(partialKey.isEmpty || associationID.isEmpty)
+  }
+
+  private var proxlockService: OpenAIService {
+    OpenAIServiceFactory.service(proxLockPartialKey: partialKey, proxLockAssociationID: associationID)
+  }
+}
+
+#Preview {
+  ApiKeyIntroView()
+}

--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ServiceSelectionView.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ServiceSelectionView.swift
@@ -23,6 +23,18 @@ struct ServiceSelectionView: View {
               .fontWeight(.light)
             }
           }
+            
+          NavigationLink(destination: ProxLockIntroView()) {
+            VStack(alignment: .leading) {
+              Text("ProxLock Service")
+                .padding(.bottom, 10)
+              Group {
+                  Text("Use this service to test SwiftOpenAI functionality with requests proxied through ProxLock for key protection.")
+              }
+              .font(.caption)
+              .fontWeight(.light)
+            }
+          }
 
           NavigationLink(destination: AIProxyIntroView()) {
             VStack(alignment: .leading) {

--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ServiceSelectionView.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ServiceSelectionView.swift
@@ -23,13 +23,14 @@ struct ServiceSelectionView: View {
               .fontWeight(.light)
             }
           }
-            
+
           NavigationLink(destination: ProxLockIntroView()) {
             VStack(alignment: .leading) {
               Text("ProxLock Service")
                 .padding(.bottom, 10)
               Group {
-                  Text("Use this service to test SwiftOpenAI functionality with requests proxied through ProxLock for key protection.")
+                Text(
+                  "Use this service to test SwiftOpenAI functionality with requests proxied through ProxLock for key protection.")
               }
               .font(.caption)
               .fontWeight(.light)

--- a/Sources/OpenAI/AIProxy/Endpoint+AIProxy.swift
+++ b/Sources/OpenAI/AIProxy/Endpoint+AIProxy.swift
@@ -45,8 +45,9 @@ extension Endpoint {
     async throws -> URLRequest
   {
     let finalPath = path(in: openAIEnvironment)
-    var request = URLRequest(url: urlComponents(serviceURL: openAIEnvironment.baseURL, path: finalPath, queryItems: queryItems)
-      .url!)
+    var request = URLRequest(
+      url: urlComponents(serviceURL: openAIEnvironment.baseURL, path: finalPath, queryItems: queryItems)
+        .url!)
     request.addValue("application/json", forHTTPHeaderField: "Content-Type")
     request.addValue(aiproxyPartialKey, forHTTPHeaderField: "aiproxy-partial-key")
     if let organizationID {
@@ -84,8 +85,9 @@ extension Endpoint {
     async throws -> URLRequest
   {
     let finalPath = path(in: openAIEnvironment)
-    var request = URLRequest(url: urlComponents(serviceURL: openAIEnvironment.baseURL, path: finalPath, queryItems: queryItems)
-      .url!)
+    var request = URLRequest(
+      url: urlComponents(serviceURL: openAIEnvironment.baseURL, path: finalPath, queryItems: queryItems)
+        .url!)
     request.httpMethod = method.rawValue
     request.addValue(aiproxyPartialKey, forHTTPHeaderField: "aiproxy-partial-key")
     if let organizationID {

--- a/Sources/OpenAI/ProxLock/Endpoint+ProxLock.swift
+++ b/Sources/OpenAI/ProxLock/Endpoint+ProxLock.swift
@@ -1,0 +1,152 @@
+//
+//  Endpoint+ProxLock.swift
+//  SwiftOpenAI
+//
+//  Created by Morris Richman on 1/2/26.
+//
+
+#if !os(Linux)
+import Foundation
+import DeviceCheck
+
+extension Endpoint {
+  func request(
+    apiKey: Authorization,
+    assosiationID: String,
+    openAIEnvironment: OpenAIEnvironment,
+    organizationID: String?,
+    method: HTTPMethod,
+    params: Encodable? = nil,
+    queryItems: [URLQueryItem] = [],
+    betaHeaderField: String? = nil,
+    extraHeaders: [String: String]? = nil)
+    async throws -> URLRequest
+  {
+    let finalPath = path(in: openAIEnvironment)
+    let components = urlComponents(base: openAIEnvironment.baseURL, path: finalPath, queryItems: queryItems)
+    guard let url = components.url else {
+      throw URLError(.badURL)
+    }
+    var request = URLRequest(url: url)
+    request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.addValue("%ProxLock_PARTIAL_KEY:\(apiKey.value)%", forHTTPHeaderField: apiKey.headerField)
+    if let organizationID {
+      request.addValue(organizationID, forHTTPHeaderField: "OpenAI-Organization")
+    }
+    if let betaHeaderField {
+      request.addValue(betaHeaderField, forHTTPHeaderField: "OpenAI-Beta")
+    }
+    if let extraHeaders {
+      for header in extraHeaders {
+        request.addValue(header.value, forHTTPHeaderField: header.key)
+      }
+    }
+    request.httpMethod = method.rawValue
+    if let params {
+      request.httpBody = try JSONEncoder().encode(params)
+    }
+      
+      request = try await processURLRequest(request, associationID: assosiationID)
+    return request
+  }
+    
+    func multiPartRequest(
+        apiKey: Authorization,
+        assosiationID: String,
+        openAIEnvironment: OpenAIEnvironment,
+        organizationID: String?,
+        method: HTTPMethod,
+        params: MultipartFormDataParameters,
+        queryItems: [URLQueryItem] = [])
+    async throws -> URLRequest
+    {
+        let finalPath = path(in: openAIEnvironment)
+        let components = urlComponents(base: openAIEnvironment.baseURL, path: finalPath, queryItems: queryItems)
+        guard let url = components.url else {
+            throw URLError(.badURL)
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = method.rawValue
+        let boundary = UUID().uuidString
+        request.addValue("%ProxLock_PARTIAL_KEY:\(apiKey.value)%", forHTTPHeaderField: apiKey.headerField)
+        if let organizationID {
+            request.addValue(organizationID, forHTTPHeaderField: "OpenAI-Organization")
+        }
+        request.addValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.httpBody = params.encode(boundary: boundary)
+        request = try await processURLRequest(request, associationID: assosiationID)
+        return request
+    }
+    
+    private func urlComponents(
+        base: String,
+        path: String,
+        queryItems: [URLQueryItem])
+    -> URLComponents
+    {
+        guard var components = URLComponents(string: base) else {
+            fatalError("Invalid base URL: \(base)")
+        }
+        components.path = path
+        if !queryItems.isEmpty {
+            components.queryItems = queryItems
+        }
+        return components
+    }
+}
+
+// MARK: - Private
+/// Translates your `URLRequest` into an object for ProxLock.
+///
+/// - Important: This does not include any form of authorization header. To use the bearer token, simply call ``bearerToken`` where you would like the real token to be constructed.
+private func processURLRequest(_ request: URLRequest, associationID: String) async throws -> URLRequest {
+    var request = request
+    
+    guard let destinationURL = request.url, let destinationMethod = request.httpMethod else {
+        throw URLError(.badURL)
+    }
+    
+    // Set proxy components
+    request.url = URL(string: "https://api.proxlock.dev/proxy")
+    request.httpMethod = "POST"
+    
+    // Update headers
+    request.setValue(destinationURL.absoluteString, forHTTPHeaderField: "ProxLock_DESTINATION")
+    request.setValue("device-check", forHTTPHeaderField: "ProxLock_VALIDATION_MODE")
+    request.setValue(destinationMethod.uppercased(), forHTTPHeaderField: "ProxLock_HTTP_METHOD")
+    request.setValue(associationID, forHTTPHeaderField: "ProxLock_ASSOCIATION_ID")
+    if let deviceCheckToken = try await getDeviceCheckToken() {
+        request.setValue(deviceCheckToken.base64EncodedString(), forHTTPHeaderField: "X-Apple-Device-Token")
+    }
+    
+    return request
+}
+
+/// Generated token used for Apple Device Check
+private func getDeviceCheckToken() async throws -> Data? {
+    #if targetEnvironment(simulator)
+    guard let bypassToken = ProcessInfo.processInfo.environment["PROXLOCK_DEVICE_CHECK_BYPASS"] else {
+        throw DCError(.featureUnsupported)
+    }
+    
+    return bypassToken.data(using: .utf8)
+    #else
+    guard DCDevice.current.isSupported else {
+        throw DCError(.featureUnsupported)
+    }
+    
+    let token: Data? = try await withCheckedThrowingContinuation { continuation in
+        DCDevice.current.generateToken { token, error in
+            if let error {
+                continuation.resume(throwing: error)
+                return
+            }
+            
+            continuation.resume(returning: token)
+        }
+    }
+    
+    return token
+    #endif
+}
+#endif

--- a/Sources/OpenAI/ProxLock/Endpoint+ProxLock.swift
+++ b/Sources/OpenAI/ProxLock/Endpoint+ProxLock.swift
@@ -6,8 +6,8 @@
 //
 
 #if !os(Linux)
-import Foundation
 import DeviceCheck
+import Foundation
 
 extension Endpoint {
   func request(
@@ -29,7 +29,7 @@ extension Endpoint {
     }
     var request = URLRequest(url: url)
     request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-      request.addValue("Bearer %ProxLock_PARTIAL_KEY:\(apiKey.value)%", forHTTPHeaderField: "Authorization")
+    request.addValue("Bearer %ProxLock_PARTIAL_KEY:\(apiKey.value)%", forHTTPHeaderField: "Authorization")
     if let organizationID {
       request.addValue(organizationID, forHTTPHeaderField: "OpenAI-Organization")
     }
@@ -45,54 +45,54 @@ extension Endpoint {
     if let params {
       request.httpBody = try JSONEncoder().encode(params)
     }
-      
-      request = try await processURLRequest(request, associationID: assosiationID)
+
+    request = try await processURLRequest(request, associationID: assosiationID)
     return request
   }
-    
-    func multiPartRequest(
-        apiKey: Authorization,
-        assosiationID: String,
-        openAIEnvironment: OpenAIEnvironment,
-        organizationID: String?,
-        method: HTTPMethod,
-        params: MultipartFormDataParameters,
-        queryItems: [URLQueryItem] = [])
+
+  func multiPartRequest(
+    apiKey: Authorization,
+    assosiationID: String,
+    openAIEnvironment: OpenAIEnvironment,
+    organizationID: String?,
+    method: HTTPMethod,
+    params: MultipartFormDataParameters,
+    queryItems: [URLQueryItem] = [])
     async throws -> URLRequest
-    {
-        let finalPath = path(in: openAIEnvironment)
-        let components = urlComponents(base: openAIEnvironment.baseURL, path: finalPath, queryItems: queryItems)
-        guard let url = components.url else {
-            throw URLError(.badURL)
-        }
-        var request = URLRequest(url: url)
-        request.httpMethod = method.rawValue
-        let boundary = UUID().uuidString
-        request.addValue("Bearer %ProxLock_PARTIAL_KEY:\(apiKey.value)%", forHTTPHeaderField: "Authorization")
-        if let organizationID {
-            request.addValue(organizationID, forHTTPHeaderField: "OpenAI-Organization")
-        }
-        request.addValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
-        request.httpBody = params.encode(boundary: boundary)
-        request = try await processURLRequest(request, associationID: assosiationID)
-        return request
+  {
+    let finalPath = path(in: openAIEnvironment)
+    let components = urlComponents(base: openAIEnvironment.baseURL, path: finalPath, queryItems: queryItems)
+    guard let url = components.url else {
+      throw URLError(.badURL)
     }
-    
-    private func urlComponents(
-        base: String,
-        path: String,
-        queryItems: [URLQueryItem])
+    var request = URLRequest(url: url)
+    request.httpMethod = method.rawValue
+    let boundary = UUID().uuidString
+    request.addValue("Bearer %ProxLock_PARTIAL_KEY:\(apiKey.value)%", forHTTPHeaderField: "Authorization")
+    if let organizationID {
+      request.addValue(organizationID, forHTTPHeaderField: "OpenAI-Organization")
+    }
+    request.addValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+    request.httpBody = params.encode(boundary: boundary)
+    request = try await processURLRequest(request, associationID: assosiationID)
+    return request
+  }
+
+  private func urlComponents(
+    base: String,
+    path: String,
+    queryItems: [URLQueryItem])
     -> URLComponents
-    {
-        guard var components = URLComponents(string: base) else {
-            fatalError("Invalid base URL: \(base)")
-        }
-        components.path = path
-        if !queryItems.isEmpty {
-            components.queryItems = queryItems
-        }
-        return components
+  {
+    guard var components = URLComponents(string: base) else {
+      fatalError("Invalid base URL: \(base)")
     }
+    components.path = path
+    if !queryItems.isEmpty {
+      components.queryItems = queryItems
+    }
+    return components
+  }
 }
 
 // MARK: - Private
@@ -100,53 +100,51 @@ extension Endpoint {
 ///
 /// - Important: This does not include any form of authorization header. To use the bearer token, simply call ``bearerToken`` where you would like the real token to be constructed.
 private func processURLRequest(_ request: URLRequest, associationID: String) async throws -> URLRequest {
-    var request = request
-    
-    guard let destinationURL = request.url, let destinationMethod = request.httpMethod else {
-        throw URLError(.badURL)
-    }
-    
-    // Set proxy components
-    request.url = URL(string: "https://api.proxlock.dev/proxy")
-    request.httpMethod = "POST"
-    
-    // Update headers
-    request.setValue(destinationURL.absoluteString, forHTTPHeaderField: "ProxLock_DESTINATION")
-    request.setValue("device-check", forHTTPHeaderField: "ProxLock_VALIDATION_MODE")
-    request.setValue(destinationMethod.uppercased(), forHTTPHeaderField: "ProxLock_HTTP_METHOD")
-    request.setValue(associationID, forHTTPHeaderField: "ProxLock_ASSOCIATION_ID")
-    if let deviceCheckToken = try await getDeviceCheckToken() {
-        request.setValue(deviceCheckToken.base64EncodedString(), forHTTPHeaderField: "X-Apple-Device-Token")
-    }
-    
-    return request
+  var request = request
+
+  guard let destinationURL = request.url, let destinationMethod = request.httpMethod else {
+    throw URLError(.badURL)
+  }
+
+  // Set proxy components
+  request.url = URL(string: "https://api.proxlock.dev/proxy")
+  request.httpMethod = "POST"
+
+  // Update headers
+  request.setValue(destinationURL.absoluteString, forHTTPHeaderField: "ProxLock_DESTINATION")
+  request.setValue("device-check", forHTTPHeaderField: "ProxLock_VALIDATION_MODE")
+  request.setValue(destinationMethod.uppercased(), forHTTPHeaderField: "ProxLock_HTTP_METHOD")
+  request.setValue(associationID, forHTTPHeaderField: "ProxLock_ASSOCIATION_ID")
+  if let deviceCheckToken = try await getDeviceCheckToken() {
+    request.setValue(deviceCheckToken.base64EncodedString(), forHTTPHeaderField: "X-Apple-Device-Token")
+  }
+
+  return request
 }
 
 /// Generated token used for Apple Device Check
 private func getDeviceCheckToken() async throws -> Data? {
-    #if targetEnvironment(simulator)
-    guard let bypassToken = ProcessInfo.processInfo.environment["PROXLOCK_DEVICE_CHECK_BYPASS"] else {
-        throw DCError(.featureUnsupported)
+  #if targetEnvironment(simulator)
+  guard let bypassToken = ProcessInfo.processInfo.environment["PROXLOCK_DEVICE_CHECK_BYPASS"] else {
+    throw DCError(.featureUnsupported)
+  }
+
+  return bypassToken.data(using: .utf8)
+  #else
+  guard DCDevice.current.isSupported else {
+    throw DCError(.featureUnsupported)
+  }
+
+  return try await withCheckedThrowingContinuation { continuation in
+    DCDevice.current.generateToken { token, error in
+      if let error {
+        continuation.resume(throwing: error)
+        return
+      }
+
+      continuation.resume(returning: token)
     }
-    
-    return bypassToken.data(using: .utf8)
-    #else
-    guard DCDevice.current.isSupported else {
-        throw DCError(.featureUnsupported)
-    }
-    
-    let token: Data? = try await withCheckedThrowingContinuation { continuation in
-        DCDevice.current.generateToken { token, error in
-            if let error {
-                continuation.resume(throwing: error)
-                return
-            }
-            
-            continuation.resume(returning: token)
-        }
-    }
-    
-    return token
-    #endif
+  }
+  #endif
 }
 #endif

--- a/Sources/OpenAI/ProxLock/Endpoint+ProxLock.swift
+++ b/Sources/OpenAI/ProxLock/Endpoint+ProxLock.swift
@@ -29,7 +29,7 @@ extension Endpoint {
     }
     var request = URLRequest(url: url)
     request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.addValue("%ProxLock_PARTIAL_KEY:\(apiKey.value)%", forHTTPHeaderField: apiKey.headerField)
+      request.addValue("Bearer %ProxLock_PARTIAL_KEY:\(apiKey.value)%", forHTTPHeaderField: "Authorization")
     if let organizationID {
       request.addValue(organizationID, forHTTPHeaderField: "OpenAI-Organization")
     }
@@ -68,7 +68,7 @@ extension Endpoint {
         var request = URLRequest(url: url)
         request.httpMethod = method.rawValue
         let boundary = UUID().uuidString
-        request.addValue("%ProxLock_PARTIAL_KEY:\(apiKey.value)%", forHTTPHeaderField: apiKey.headerField)
+        request.addValue("Bearer %ProxLock_PARTIAL_KEY:\(apiKey.value)%", forHTTPHeaderField: "Authorization")
         if let organizationID {
             request.addValue(organizationID, forHTTPHeaderField: "OpenAI-Organization")
         }

--- a/Sources/OpenAI/ProxLock/ProxLockService.swift
+++ b/Sources/OpenAI/ProxLock/ProxLockService.swift
@@ -1,0 +1,1691 @@
+//
+//  DefaultOpenAIService.swift
+//
+//
+//  Created by James Rochabrun on 10/17/23.
+//
+
+import Foundation
+
+#if !os(Linux)
+enum ProxLockServiceError: Error {
+    case unsupportedFunction(String)
+    
+    var localizedDescription: String {
+        switch self {
+        case .unsupportedFunction(let function):
+            return "\(function) is not yet supported for ProxLock. Please use DefaultOpenAIService instead."
+        }
+    }
+}
+
+struct ProxLockOpenAIService: OpenAIService {
+  init(
+    partialKey: String,
+    assosiationID: String,
+    organizationID: String? = nil,
+    baseURL: String? = nil,
+    proxyPath: String? = nil,
+    overrideVersion: String? = nil,
+    extraHeaders: [String: String]? = nil,
+    httpClient: HTTPClient,
+    decoder: JSONDecoder = .init(),
+    debugEnabled: Bool)
+  {
+    self.httpClient = httpClient
+    self.decoder = decoder
+      self.apiKey = .bearer(partialKey)
+      self.assosiationID = assosiationID
+    self.organizationID = organizationID
+    self.extraHeaders = extraHeaders
+    openAIEnvironment = OpenAIEnvironment(
+      baseURL: baseURL ?? "https://api.openai.com",
+      proxyPath: proxyPath,
+      version: overrideVersion ?? "v1")
+    self.debugEnabled = debugEnabled
+  }
+
+  let httpClient: HTTPClient
+  let decoder: JSONDecoder
+  let openAIEnvironment: OpenAIEnvironment
+
+  // MARK: Audio
+
+  func createTranscription(
+    parameters: AudioTranscriptionParameters)
+    async throws -> AudioObject
+  {
+      let request = try await OpenAIAPI.audio(.transcriptions).multiPartRequest(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters)
+    return try await fetch(debugEnabled: debugEnabled, type: AudioObject.self, with: request)
+  }
+
+  func createTranslation(
+    parameters: AudioTranslationParameters)
+    async throws -> AudioObject
+  {
+    let request = try await OpenAIAPI.audio(.translations).multiPartRequest(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters)
+    return try await fetch(debugEnabled: debugEnabled, type: AudioObject.self, with: request)
+  }
+
+  func createSpeech(
+    parameters: AudioSpeechParameters)
+    async throws -> AudioSpeechObject
+  {
+    let request = try await OpenAIAPI.audio(.speech).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      extraHeaders: extraHeaders)
+    let data = try await fetchAudio(with: request)
+    return AudioSpeechObject(output: data)
+  }
+
+  #if canImport(AVFoundation)
+  func realtimeSession(
+    model: String,
+    configuration: OpenAIRealtimeSessionConfiguration)
+    async throws -> OpenAIRealtimeSession
+  {
+      throw ProxLockServiceError.unsupportedFunction("Realtime Session")
+  }
+  #endif
+
+  // MARK: Chat
+
+  func startChat(
+    parameters: ChatCompletionParameters)
+    async throws -> ChatCompletionObject
+  {
+    var chatParameters = parameters
+    chatParameters.stream = false
+    let request = try await OpenAIAPI.chat.request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: chatParameters,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: ChatCompletionObject.self, with: request)
+  }
+
+  func startStreamedChat(
+    parameters: ChatCompletionParameters)
+    async throws -> AsyncThrowingStream<ChatCompletionChunkObject, Error>
+  {
+    var chatParameters = parameters
+    chatParameters.stream = true
+    let request = try await OpenAIAPI.chat.request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: chatParameters,
+      extraHeaders: extraHeaders)
+    return try await fetchStream(debugEnabled: debugEnabled, type: ChatCompletionChunkObject.self, with: request)
+  }
+
+  // MARK: Embeddings
+
+  func createEmbeddings(
+    parameters: EmbeddingParameter)
+    async throws -> OpenAIResponse<EmbeddingObject>
+  {
+    let request = try await OpenAIAPI.embeddings.request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<EmbeddingObject>.self, with: request)
+  }
+
+  // MARK: Fine-tuning
+
+  func createFineTuningJob(
+    parameters: FineTuningJobParameters)
+    async throws -> FineTuningJobObject
+  {
+    let request = try await OpenAIAPI.fineTuning(.create).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: FineTuningJobObject.self, with: request)
+  }
+
+  func listFineTuningJobs(
+    after lastJobID: String? = nil,
+    limit: Int? = nil)
+    async throws -> OpenAIResponse<FineTuningJobObject>
+  {
+    var queryItems = [URLQueryItem]()
+    if let lastJobID, let limit {
+      queryItems = [.init(name: "after", value: lastJobID), .init(name: "limit", value: "\(limit)")]
+    } else if let lastJobID {
+      queryItems = [.init(name: "after", value: lastJobID)]
+    } else if let limit {
+      queryItems = [.init(name: "limit", value: "\(limit)")]
+    }
+
+    let request = try await OpenAIAPI.fineTuning(.list).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      queryItems: queryItems,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<FineTuningJobObject>.self, with: request)
+  }
+
+  func retrieveFineTuningJob(
+    id: String)
+    async throws -> FineTuningJobObject
+  {
+    let request = try await OpenAIAPI.fineTuning(.retrieve(jobID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: FineTuningJobObject.self, with: request)
+  }
+
+  func cancelFineTuningJobWith(
+    id: String)
+    async throws -> FineTuningJobObject
+  {
+    let request = try await OpenAIAPI.fineTuning(.cancel(jobID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: FineTuningJobObject.self, with: request)
+  }
+
+  func listFineTuningEventsForJobWith(
+    id: String,
+    after lastEventId: String? = nil,
+    limit: Int? = nil)
+    async throws -> OpenAIResponse<FineTuningJobEventObject>
+  {
+    var queryItems = [URLQueryItem]()
+    if let lastEventId, let limit {
+      queryItems = [.init(name: "after", value: lastEventId), .init(name: "limit", value: "\(limit)")]
+    } else if let lastEventId {
+      queryItems = [.init(name: "after", value: lastEventId)]
+    } else if let limit {
+      queryItems = [.init(name: "limit", value: "\(limit)")]
+    }
+    let request = try await OpenAIAPI.fineTuning(.events(jobID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      queryItems: queryItems,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<FineTuningJobEventObject>.self, with: request)
+  }
+
+  // MARK: Files
+
+  func listFiles()
+    async throws -> OpenAIResponse<FileObject>
+  {
+    let request = try await OpenAIAPI.file(.list).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<FileObject>.self, with: request)
+  }
+
+  func uploadFile(
+    parameters: FileParameters)
+    async throws -> FileObject
+  {
+    let request = try await OpenAIAPI.file(.upload).multiPartRequest(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters)
+    return try await fetch(debugEnabled: debugEnabled, type: FileObject.self, with: request)
+  }
+
+  func deleteFileWith(
+    id: String)
+    async throws -> DeletionStatus
+  {
+    let request = try await OpenAIAPI.file(.delete(fileID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .delete,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
+  }
+
+  func retrieveFileWith(
+    id: String)
+    async throws -> FileObject
+  {
+    let request = try await OpenAIAPI.file(.retrieve(fileID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: FileObject.self, with: request)
+  }
+
+  func retrieveContentForFileWith(
+    id: String)
+    async throws -> [[String: Any]]
+  {
+    let request = try await OpenAIAPI.file(.retrieveFileContent(fileID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      extraHeaders: extraHeaders)
+    return try await fetchContentsOfFile(request: request)
+  }
+
+  // MARK: Images
+
+  func legacyCreateImages(
+    parameters: ImageCreateParameters)
+    async throws -> OpenAIResponse<ImageObject>
+  {
+    let request = try await OpenAIAPI.images(.generations).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<ImageObject>.self, with: request)
+  }
+
+  func legacyEditImage(
+    parameters: ImageEditParameters)
+    async throws -> OpenAIResponse<ImageObject>
+  {
+    let request = try await OpenAIAPI.images(.edits).multiPartRequest(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters)
+    return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<ImageObject>.self, with: request)
+  }
+
+  func legacyCreateImageVariations(
+    parameters: ImageVariationParameters)
+    async throws -> OpenAIResponse<ImageObject>
+  {
+    let request = try await OpenAIAPI.images(.variations).multiPartRequest(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters)
+    return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<ImageObject>.self, with: request)
+  }
+
+  func createImages(
+    parameters: CreateImageParameters)
+    async throws -> CreateImageResponse
+  {
+    let request = try await OpenAIAPI.images(.generations).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: CreateImageResponse.self, with: request)
+  }
+
+  func editImage(
+    parameters: CreateImageEditParameters)
+    async throws -> CreateImageResponse
+  {
+    let request = try await OpenAIAPI.images(.edits).multiPartRequest(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters)
+    return try await fetch(debugEnabled: debugEnabled, type: CreateImageResponse.self, with: request)
+  }
+
+  func createImageVariations(
+    parameters: CreateImageVariationParameters)
+    async throws -> CreateImageResponse
+  {
+    let request = try await OpenAIAPI.images(.variations).multiPartRequest(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters)
+    return try await fetch(debugEnabled: debugEnabled, type: CreateImageResponse.self, with: request)
+  }
+
+  // MARK: Models
+
+  func listModels()
+    async throws -> OpenAIResponse<ModelObject>
+  {
+    let request = try await OpenAIAPI.model(.list).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<ModelObject>.self, with: request)
+  }
+
+  func retrieveModelWith(
+    id: String)
+    async throws -> ModelObject
+  {
+    let request = try await OpenAIAPI.model(.retrieve(modelID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: ModelObject.self, with: request)
+  }
+
+  func deleteFineTuneModelWith(
+    id: String)
+    async throws -> DeletionStatus
+  {
+    let request = try await OpenAIAPI.model(.deleteFineTuneModel(modelID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .delete,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
+  }
+
+  // MARK: Moderations
+
+  func createModerationFromText(
+    parameters: ModerationParameter<String>)
+    async throws -> ModerationObject
+  {
+    let request = try await OpenAIAPI.moderations.request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: ModerationObject.self, with: request)
+  }
+
+  func createModerationFromTexts(
+    parameters: ModerationParameter<[String]>)
+    async throws -> ModerationObject
+  {
+    let request = try await OpenAIAPI.moderations.request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: ModerationObject.self, with: request)
+  }
+
+  // MARK: Assistants [BETA]
+
+  func createAssistant(
+    parameters: AssistantParameters)
+    async throws -> AssistantObject
+  {
+    let request = try await OpenAIAPI.assistant(.create).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: AssistantObject.self, with: request)
+  }
+
+  func retrieveAssistant(
+    id: String)
+    async throws -> AssistantObject
+  {
+    let request = try await OpenAIAPI.assistant(.retrieve(assistantID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: AssistantObject.self, with: request)
+  }
+
+  func modifyAssistant(
+    id: String,
+    parameters: AssistantParameters)
+    async throws -> AssistantObject
+  {
+    let request = try await OpenAIAPI.assistant(.modify(assistantID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: AssistantObject.self, with: request)
+  }
+
+  func deleteAssistant(
+    id: String)
+    async throws -> DeletionStatus
+  {
+    let request = try await OpenAIAPI.assistant(.delete(assistantID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .delete,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
+  }
+
+  func listAssistants(
+    limit: Int? = nil,
+    order: String? = nil,
+    after: String? = nil,
+    before: String? = nil)
+    async throws -> OpenAIResponse<AssistantObject>
+  {
+    var queryItems = [URLQueryItem]()
+    if let limit {
+      queryItems.append(.init(name: "limit", value: "\(limit)"))
+    }
+    if let order {
+      queryItems.append(.init(name: "order", value: order))
+    }
+    if let after {
+      queryItems.append(.init(name: "after", value: after))
+    }
+    if let before {
+      queryItems.append(.init(name: "before", value: before))
+    }
+    let request = try await OpenAIAPI.assistant(.list).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      queryItems: queryItems,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<AssistantObject>.self, with: request)
+  }
+
+  // MARK: Thread [BETA]
+
+  func createThread(
+    parameters: CreateThreadParameters)
+    async throws -> ThreadObject
+  {
+    let request = try await OpenAIAPI.thread(.create).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: ThreadObject.self, with: request)
+  }
+
+  func retrieveThread(id: String)
+    async throws -> ThreadObject
+  {
+    let request = try await OpenAIAPI.thread(.retrieve(threadID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: ThreadObject.self, with: request)
+  }
+
+  func modifyThread(
+    id: String,
+    parameters: ModifyThreadParameters)
+    async throws -> ThreadObject
+  {
+    let request = try await OpenAIAPI.thread(.modify(threadID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: ThreadObject.self, with: request)
+  }
+
+  func deleteThread(
+    id: String)
+    async throws -> DeletionStatus
+  {
+    let request = try await OpenAIAPI.thread(.delete(threadID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .delete,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
+  }
+
+  // MARK: Message [BETA]
+
+  func createMessage(
+    threadID: String,
+    parameters: MessageParameter)
+    async throws -> MessageObject
+  {
+    let request = try await OpenAIAPI.message(.create(threadID: threadID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: MessageObject.self, with: request)
+  }
+
+  func retrieveMessage(
+    threadID: String,
+    messageID: String)
+    async throws -> MessageObject
+  {
+    let request = try await OpenAIAPI.message(.retrieve(threadID: threadID, messageID: messageID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: MessageObject.self, with: request)
+  }
+
+  func modifyMessage(
+    threadID: String,
+    messageID: String,
+    parameters: ModifyMessageParameters)
+    async throws -> MessageObject
+  {
+    let request = try await OpenAIAPI.message(.modify(threadID: threadID, messageID: messageID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: MessageObject.self, with: request)
+  }
+
+  func deleteMessage(
+    threadID: String,
+    messageID: String)
+    async throws -> DeletionStatus
+  {
+    let request = try await OpenAIAPI.message(.delete(threadID: threadID, messageID: messageID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .delete,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
+  }
+
+  func listMessages(
+    threadID: String,
+    limit: Int? = nil,
+    order: String? = nil,
+    after: String? = nil,
+    before: String? = nil,
+    runID: String? = nil)
+    async throws -> OpenAIResponse<MessageObject>
+  {
+    var queryItems = [URLQueryItem]()
+    if let limit {
+      queryItems.append(.init(name: "limit", value: "\(limit)"))
+    }
+    if let order {
+      queryItems.append(.init(name: "order", value: order))
+    }
+    if let after {
+      queryItems.append(.init(name: "after", value: after))
+    }
+    if let before {
+      queryItems.append(.init(name: "before", value: before))
+    }
+    if let runID {
+      queryItems.append(.init(name: "run_id", value: runID))
+    }
+    let request = try await OpenAIAPI.message(.list(threadID: threadID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      queryItems: queryItems,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<MessageObject>.self, with: request)
+  }
+
+  // MARK: Run [BETA]
+
+  func createRun(
+    threadID: String,
+    parameters: RunParameter)
+    async throws -> RunObject
+  {
+    let request = try await OpenAIAPI.run(.create(threadID: threadID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
+  }
+
+  func retrieveRun(
+    threadID: String,
+    runID: String)
+    async throws -> RunObject
+  {
+    let request = try await OpenAIAPI.run(.retrieve(threadID: threadID, runID: runID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
+  }
+
+  func modifyRun(
+    threadID: String,
+    runID: String,
+    parameters: ModifyRunParameters)
+    async throws -> RunObject
+  {
+    let request = try await OpenAIAPI.run(.modify(threadID: threadID, runID: runID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
+  }
+
+  func listRuns(
+    threadID: String,
+    limit: Int? = nil,
+    order: String? = nil,
+    after: String? = nil,
+    before: String? = nil)
+    async throws -> OpenAIResponse<RunObject>
+  {
+    var queryItems = [URLQueryItem]()
+    if let limit {
+      queryItems.append(.init(name: "limit", value: "\(limit)"))
+    }
+    if let order {
+      queryItems.append(.init(name: "order", value: order))
+    }
+    if let after {
+      queryItems.append(.init(name: "after", value: after))
+    }
+    if let before {
+      queryItems.append(.init(name: "before", value: before))
+    }
+    let request = try await OpenAIAPI.run(.list(threadID: threadID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      queryItems: queryItems,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<RunObject>.self, with: request)
+  }
+
+  func cancelRun(
+    threadID: String,
+    runID: String)
+    async throws -> RunObject
+  {
+    let request = try await OpenAIAPI.run(.cancel(threadID: threadID, runID: runID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
+  }
+
+  func submitToolOutputsToRun(
+    threadID: String,
+    runID: String,
+    parameters: RunToolsOutputParameter)
+    async throws -> RunObject
+  {
+    let request = try await OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
+  }
+
+  func createThreadAndRun(
+    parameters: CreateThreadAndRunParameter)
+    async throws -> RunObject
+  {
+    let request = try await OpenAIAPI.run(.createThreadAndRun).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: RunObject.self, with: request)
+  }
+
+  // MARK: Run Step [BETA]
+
+  func retrieveRunstep(
+    threadID: String,
+    runID: String,
+    stepID: String)
+    async throws -> RunStepObject
+  {
+    let request = try await OpenAIAPI.runStep(.retrieve(threadID: threadID, runID: runID, stepID: stepID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: RunStepObject.self, with: request)
+  }
+
+  func listRunSteps(
+    threadID: String,
+    runID: String,
+    limit: Int? = nil,
+    order: String? = nil,
+    after: String? = nil,
+    before: String? = nil)
+    async throws -> OpenAIResponse<RunStepObject>
+  {
+    var queryItems = [URLQueryItem]()
+    if let limit {
+      queryItems.append(.init(name: "limit", value: "\(limit)"))
+    }
+    if let order {
+      queryItems.append(.init(name: "order", value: order))
+    }
+    if let after {
+      queryItems.append(.init(name: "after", value: after))
+    }
+    if let before {
+      queryItems.append(.init(name: "before", value: before))
+    }
+    let request = try await OpenAIAPI.runStep(.list(threadID: threadID, runID: runID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      queryItems: queryItems,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<RunStepObject>.self, with: request)
+  }
+
+  func createRunStream(
+    threadID: String,
+    parameters: RunParameter)
+    async throws -> AsyncThrowingStream<AssistantStreamEvent, Error>
+  {
+    var runParameters = parameters
+    runParameters.stream = true
+    let request = try await OpenAIAPI.run(.create(threadID: threadID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: runParameters,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetchAssistantStreamEvents(with: request, debugEnabled: debugEnabled)
+  }
+
+  func createThreadAndRunStream(
+    parameters: CreateThreadAndRunParameter)
+    async throws -> AsyncThrowingStream<AssistantStreamEvent, Error>
+  {
+    var runParameters = parameters
+    runParameters.stream = true
+    let request = try await OpenAIAPI.run(.createThreadAndRun).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetchAssistantStreamEvents(with: request, debugEnabled: debugEnabled)
+  }
+
+  func submitToolOutputsToRunStream(
+    threadID: String,
+    runID: String,
+    parameters: RunToolsOutputParameter)
+    async throws -> AsyncThrowingStream<AssistantStreamEvent, Error>
+  {
+    var runToolsOutputParameter = parameters
+    runToolsOutputParameter.stream = true
+    let request = try await OpenAIAPI.run(.submitToolOutput(threadID: threadID, runID: runID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: runToolsOutputParameter,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetchAssistantStreamEvents(with: request, debugEnabled: debugEnabled)
+  }
+
+  // MARK: Batch
+
+  func createBatch(
+    parameters: BatchParameter)
+    async throws -> BatchObject
+  {
+    let request = try await OpenAIAPI.batch(.create).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: BatchObject.self, with: request)
+  }
+
+  func retrieveBatch(
+    id: String)
+    async throws -> BatchObject
+  {
+    let request = try await OpenAIAPI.batch(.retrieve(batchID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: BatchObject.self, with: request)
+  }
+
+  func cancelBatch(
+    id: String)
+    async throws -> BatchObject
+  {
+    let request = try await OpenAIAPI.batch(.cancel(batchID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: BatchObject.self, with: request)
+  }
+
+  func listBatch(
+    after: String? = nil,
+    limit: Int? = nil)
+    async throws -> OpenAIResponse<BatchObject>
+  {
+    var queryItems = [URLQueryItem]()
+    if let limit {
+      queryItems.append(.init(name: "limit", value: "\(limit)"))
+    }
+    if let after {
+      queryItems.append(.init(name: "after", value: after))
+    }
+    let request = try await OpenAIAPI.batch(.list).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      queryItems: queryItems,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<BatchObject>.self, with: request)
+  }
+
+  // MARK: Vector Store
+
+  func createVectorStore(
+    parameters: VectorStoreParameter)
+    async throws -> VectorStoreObject
+  {
+    let request = try await OpenAIAPI.vectorStore(.create).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: VectorStoreObject.self, with: request)
+  }
+
+  func listVectorStores(
+    limit: Int? = nil,
+    order: String? = nil,
+    after: String? = nil,
+    before: String? = nil)
+    async throws -> OpenAIResponse<VectorStoreObject>
+  {
+    var queryItems = [URLQueryItem]()
+    if let limit {
+      queryItems.append(.init(name: "limit", value: "\(limit)"))
+    }
+    if let order {
+      queryItems.append(.init(name: "order", value: order))
+    }
+    if let after {
+      queryItems.append(.init(name: "after", value: after))
+    }
+    if let before {
+      queryItems.append(.init(name: "before", value: before))
+    }
+    let request = try await OpenAIAPI.vectorStore(.list).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      queryItems: queryItems,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<VectorStoreObject>.self, with: request)
+  }
+
+  func retrieveVectorStore(
+    id: String)
+    async throws -> VectorStoreObject
+  {
+    let request = try await OpenAIAPI.vectorStore(.retrieve(vectorStoreID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: VectorStoreObject.self, with: request)
+  }
+
+  func modifyVectorStore(
+    parameters: VectorStoreParameter,
+    id: String)
+    async throws -> VectorStoreObject
+  {
+    let request = try await OpenAIAPI.vectorStore(.modify(vectorStoreID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: VectorStoreObject.self, with: request)
+  }
+
+  func deleteVectorStore(
+    id: String)
+    async throws -> DeletionStatus
+  {
+    let request = try await OpenAIAPI.vectorStore(.modify(vectorStoreID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .delete,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
+  }
+
+  // MARK: Vector Store Files
+
+  func createVectorStoreFile(
+    vectorStoreID: String,
+    parameters: VectorStoreFileParameter)
+    async throws -> VectorStoreFileObject
+  {
+    let request = try await OpenAIAPI.vectorStoreFile(.create(vectorStoreID: vectorStoreID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: VectorStoreFileObject.self, with: request)
+  }
+
+  func listVectorStoreFiles(
+    vectorStoreID: String,
+    limit: Int? = nil,
+    order: String? = nil,
+    after: String? = nil,
+    before: String? = nil,
+    filter: String? = nil)
+    async throws -> OpenAIResponse<VectorStoreFileObject>
+  {
+    var queryItems = [URLQueryItem]()
+    if let limit {
+      queryItems.append(.init(name: "limit", value: "\(limit)"))
+    }
+    if let order {
+      queryItems.append(.init(name: "order", value: order))
+    }
+    if let after {
+      queryItems.append(.init(name: "after", value: after))
+    }
+    if let before {
+      queryItems.append(.init(name: "before", value: before))
+    }
+    if let filter {
+      queryItems.append(.init(name: "filter", value: filter))
+    }
+    let request = try await OpenAIAPI.vectorStoreFile(.list(vectorStoreID: vectorStoreID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      queryItems: queryItems,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<VectorStoreFileObject>.self, with: request)
+  }
+
+  func retrieveVectorStoreFile(
+    vectorStoreID: String,
+    fileID: String)
+    async throws -> VectorStoreFileObject
+  {
+    let request = try await OpenAIAPI.vectorStoreFile(.retrieve(vectorStoreID: vectorStoreID, fileID: fileID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: VectorStoreFileObject.self, with: request)
+  }
+
+  func deleteVectorStoreFile(
+    vectorStoreID: String,
+    fileID: String)
+    async throws -> DeletionStatus
+  {
+    let request = try await OpenAIAPI.vectorStoreFile(.delete(vectorStoreID: vectorStoreID, fileID: fileID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .delete,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
+  }
+
+  // MARK: Vector Store File Batch
+
+  func createVectorStoreFileBatch(
+    vectorStoreID: String,
+    parameters: VectorStoreFileBatchParameter)
+    async throws -> VectorStoreFileBatchObject
+  {
+    let request = try await OpenAIAPI.vectorStoreFileBatch(.create(vectorStoreID: vectorStoreID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: VectorStoreFileBatchObject.self, with: request)
+  }
+
+  func retrieveVectorStoreFileBatch(
+    vectorStoreID: String,
+    batchID: String)
+    async throws -> VectorStoreFileBatchObject
+  {
+    let request = try await OpenAIAPI.vectorStoreFileBatch(.retrieve(vectorStoreID: vectorStoreID, batchID: batchID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: VectorStoreFileBatchObject.self, with: request)
+  }
+
+  func cancelVectorStoreFileBatch(
+    vectorStoreID: String,
+    batchID: String)
+    async throws -> VectorStoreFileBatchObject
+  {
+    let request = try await OpenAIAPI.vectorStoreFileBatch(.cancel(vectorStoreID: vectorStoreID, batchID: batchID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: VectorStoreFileBatchObject.self, with: request)
+  }
+
+  func listVectorStoreFilesInABatch(
+    vectorStoreID: String,
+    batchID: String,
+    limit: Int? = nil,
+    order: String? = nil,
+    after: String? = nil,
+    before: String? = nil,
+    filter: String? = nil)
+    async throws -> OpenAIResponse<VectorStoreFileObject>
+  {
+    var queryItems = [URLQueryItem]()
+    if let limit {
+      queryItems.append(.init(name: "limit", value: "\(limit)"))
+    }
+    if let order {
+      queryItems.append(.init(name: "order", value: order))
+    }
+    if let after {
+      queryItems.append(.init(name: "after", value: after))
+    }
+    if let before {
+      queryItems.append(.init(name: "before", value: before))
+    }
+    if let filter {
+      queryItems.append(.init(name: "filter", value: filter))
+    }
+    let request = try await OpenAIAPI.vectorStoreFileBatch(.list(vectorStoreID: vectorStoreID, batchID: batchID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      queryItems: queryItems,
+      betaHeaderField: Self.assistantsBetaV2,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<VectorStoreFileObject>.self, with: request)
+  }
+
+  // MARK: Response
+
+  func responseCreate(
+    _ parameters: ModelResponseParameter)
+    async throws -> ResponseModel
+  {
+    var responseParameters = parameters
+    responseParameters.stream = false
+    let request = try await OpenAIAPI.response(.create).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: responseParameters,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: ResponseModel.self, with: request)
+  }
+
+  func responseModel(
+    id: String,
+    parameters: GetResponseParameter? = nil)
+    async throws -> ResponseModel
+  {
+    var queryItems = [URLQueryItem]()
+
+    if let parameters {
+      if let include = parameters.include {
+        for item in include {
+          queryItems.append(URLQueryItem(name: "include", value: item))
+        }
+      }
+      if let includeObfuscation = parameters.includeObfuscation {
+        queryItems.append(URLQueryItem(name: "include_obfuscation", value: String(includeObfuscation)))
+      }
+      if let startingAfter = parameters.startingAfter {
+        queryItems.append(URLQueryItem(name: "starting_after", value: String(startingAfter)))
+      }
+      if let stream = parameters.stream {
+        queryItems.append(URLQueryItem(name: "stream", value: String(stream)))
+      }
+    }
+
+    let request = try await OpenAIAPI.response(.get(responseID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      queryItems: queryItems,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: ResponseModel.self, with: request)
+  }
+
+  func responseModelStream(
+    id: String,
+    parameters: GetResponseParameter? = nil)
+    async throws -> AsyncThrowingStream<ResponseStreamEvent, Error>
+  {
+    var streamParameters = parameters ?? GetResponseParameter()
+    streamParameters.stream = true
+
+    var queryItems = [URLQueryItem]()
+
+    if let include = streamParameters.include {
+      for item in include {
+        queryItems.append(URLQueryItem(name: "include", value: item))
+      }
+    }
+    if let includeObfuscation = streamParameters.includeObfuscation {
+      queryItems.append(URLQueryItem(name: "include_obfuscation", value: String(includeObfuscation)))
+    }
+    if let startingAfter = streamParameters.startingAfter {
+      queryItems.append(URLQueryItem(name: "starting_after", value: String(startingAfter)))
+    }
+    if let stream = streamParameters.stream {
+      queryItems.append(URLQueryItem(name: "stream", value: String(stream)))
+    }
+
+    let request = try await OpenAIAPI.response(.get(responseID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      queryItems: queryItems,
+      extraHeaders: extraHeaders)
+    return try await fetchStream(debugEnabled: debugEnabled, type: ResponseStreamEvent.self, with: request)
+  }
+
+  func responseCreateStream(
+    _ parameters: ModelResponseParameter)
+    async throws -> AsyncThrowingStream<ResponseStreamEvent, Error>
+  {
+    var responseParameters = parameters
+    responseParameters.stream = true
+    let request = try await OpenAIAPI.response(.create).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: responseParameters,
+      extraHeaders: extraHeaders)
+    return try await fetchStream(debugEnabled: debugEnabled, type: ResponseStreamEvent.self, with: request)
+  }
+
+  func responseDelete(
+    id: String)
+    async throws -> DeletionStatus
+  {
+    let request = try await OpenAIAPI.response(.delete(responseID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .delete,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
+  }
+
+  func responseCancel(
+    id: String)
+    async throws -> ResponseModel
+  {
+    let request = try await OpenAIAPI.response(.cancel(responseID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: ResponseModel.self, with: request)
+  }
+
+  func responseInputItems(
+    id: String,
+    parameters: GetInputItemsParameter?)
+    async throws -> OpenAIResponse<InputItem>
+  {
+    var queryItems = [URLQueryItem]()
+
+    if let parameters {
+      if let after = parameters.after {
+        queryItems.append(URLQueryItem(name: "after", value: after))
+      }
+      if let include = parameters.include {
+        for item in include {
+          queryItems.append(URLQueryItem(name: "include", value: item))
+        }
+      }
+      if let limit = parameters.limit {
+        queryItems.append(URLQueryItem(name: "limit", value: String(limit)))
+      }
+      if let order = parameters.order {
+        queryItems.append(URLQueryItem(name: "order", value: order))
+      }
+    }
+
+    let request = try await OpenAIAPI.response(.inputItems(responseID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      queryItems: queryItems,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<InputItem>.self, with: request)
+  }
+
+  // MARK: - Conversations
+
+  func conversationCreate(
+    parameters: CreateConversationParameter?)
+    async throws -> ConversationModel
+  {
+    let request = try await OpenAIAPI.conversantions(.create).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: ConversationModel.self, with: request)
+  }
+
+  func getConversation(
+    id: String)
+    async throws -> ConversationModel
+  {
+    let request = try await OpenAIAPI.conversantions(.get(conversationID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: ConversationModel.self, with: request)
+  }
+
+  func updateConversation(
+    id: String,
+    parameters: UpdateConversationParameter)
+    async throws -> ConversationModel
+  {
+    let request = try await OpenAIAPI.conversantions(.update(conversationID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: parameters,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: ConversationModel.self, with: request)
+  }
+
+  func deleteConversation(
+    id: String)
+    async throws -> DeletionStatus
+  {
+    let request = try await OpenAIAPI.conversantions(.delete(conversationID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .delete,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: DeletionStatus.self, with: request)
+  }
+
+  func getConversationItems(
+    id: String,
+    parameters: GetConversationItemsParameter?)
+    async throws -> OpenAIResponse<InputItem>
+  {
+    var queryItems = [URLQueryItem]()
+    if let parameters {
+      if let after = parameters.after {
+        queryItems.append(URLQueryItem(name: "after", value: after))
+      }
+      if let include = parameters.include {
+        for item in include {
+          queryItems.append(URLQueryItem(name: "include", value: item))
+        }
+      }
+      if let limit = parameters.limit {
+        queryItems.append(URLQueryItem(name: "limit", value: String(limit)))
+      }
+      if let order = parameters.order {
+        queryItems.append(URLQueryItem(name: "order", value: order))
+      }
+    }
+    let request = try await OpenAIAPI.conversantions(.items(conversationID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      queryItems: queryItems,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<InputItem>.self, with: request)
+  }
+
+  func createConversationItems(
+    id: String,
+    parameters: CreateConversationItemsParameter)
+    async throws -> OpenAIResponse<InputItem>
+  {
+    var queryItems = [URLQueryItem]()
+    if let include = parameters.include {
+      for item in include {
+        queryItems.append(URLQueryItem(name: "include", value: item))
+      }
+    }
+
+    // Create a body-only parameter struct for encoding
+    struct BodyParameters: Codable {
+      let items: [InputItem]
+    }
+    let bodyParams = BodyParameters(items: parameters.items)
+
+    let request = try await OpenAIAPI.conversantions(.createItems(conversationID: id)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .post,
+      params: bodyParams,
+      queryItems: queryItems,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: OpenAIResponse<InputItem>.self, with: request)
+  }
+
+  func getConversationItem(
+    conversationID: String,
+    itemID: String,
+    parameters: GetConversationItemParameter?)
+    async throws -> InputItem
+  {
+    var queryItems = [URLQueryItem]()
+    if let parameters, let include = parameters.include {
+      for item in include {
+        queryItems.append(URLQueryItem(name: "include", value: item))
+      }
+    }
+    let request = try await OpenAIAPI.conversantions(.item(conversationID: conversationID, itemID: itemID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .get,
+      queryItems: queryItems,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: InputItem.self, with: request)
+  }
+
+  func deleteConversationItem(
+    conversationID: String,
+    itemID: String)
+    async throws -> ConversationModel
+  {
+    let request = try await OpenAIAPI.conversantions(.deleteItem(conversationID: conversationID, itemID: itemID)).request(
+      apiKey: apiKey,
+      assosiationID: assosiationID,
+      openAIEnvironment: openAIEnvironment,
+      organizationID: organizationID,
+      method: .delete,
+      extraHeaders: extraHeaders)
+    return try await fetch(debugEnabled: debugEnabled, type: ConversationModel.self, with: request)
+  }
+
+  private static let assistantsBetaV2 = "assistants=v2"
+
+  /// The partial key for ProxLock
+  private let apiKey: Authorization
+    /// The id for a this key in ProxLock.
+    public let assosiationID: String
+  /// [organization](https://platform.openai.com/docs/api-reference/organization-optional)
+  private let organizationID: String?
+  /// Set this flag to TRUE if you need to print request events in DEBUG builds.
+  private let debugEnabled: Bool
+  /// Extra headers for the request.
+  private let extraHeaders: [String: String]?
+}
+
+#endif

--- a/Sources/OpenAI/ProxLock/ProxLockService.swift
+++ b/Sources/OpenAI/ProxLock/ProxLockService.swift
@@ -9,14 +9,14 @@ import Foundation
 
 #if !os(Linux)
 enum ProxLockServiceError: Error {
-    case unsupportedFunction(String)
-    
-    var localizedDescription: String {
-        switch self {
-        case .unsupportedFunction(let function):
-            return "\(function) is not yet supported for ProxLock. Please use DefaultOpenAIService instead."
-        }
+  case unsupportedFunction(String)
+
+  var localizedDescription: String {
+    switch self {
+    case .unsupportedFunction(let function):
+      "\(function) is not yet supported for ProxLock. Please use DefaultOpenAIService instead."
     }
+  }
 }
 
 /// The ProxLockOpenAIService acts nearly identically to ``DefaultOpenAIService``, but the requests it sends are processed to proxy through api.proxlock.dev at the last step. This makes maintenance a lot easier as everything is the same except for the request at its last step.
@@ -37,8 +37,8 @@ struct ProxLockOpenAIService: OpenAIService {
   {
     self.httpClient = httpClient
     self.decoder = decoder
-      self.apiKey = .apiKey(partialKey)
-      self.assosiationID = assosiationID
+    apiKey = .apiKey(partialKey)
+    self.assosiationID = assosiationID
     self.organizationID = organizationID
     self.extraHeaders = extraHeaders
     openAIEnvironment = OpenAIEnvironment(
@@ -47,6 +47,9 @@ struct ProxLockOpenAIService: OpenAIService {
       version: overrideVersion ?? "v1")
     self.debugEnabled = debugEnabled
   }
+
+  /// The id for a this key in ProxLock.
+  public let assosiationID: String
 
   let httpClient: HTTPClient
   let decoder: JSONDecoder
@@ -58,7 +61,7 @@ struct ProxLockOpenAIService: OpenAIService {
     parameters: AudioTranscriptionParameters)
     async throws -> AudioObject
   {
-      let request = try await OpenAIAPI.audio(.transcriptions).multiPartRequest(
+    let request = try await OpenAIAPI.audio(.transcriptions).multiPartRequest(
       apiKey: apiKey,
       assosiationID: assosiationID,
       openAIEnvironment: openAIEnvironment,
@@ -100,11 +103,11 @@ struct ProxLockOpenAIService: OpenAIService {
 
   #if canImport(AVFoundation)
   func realtimeSession(
-    model: String,
-    configuration: OpenAIRealtimeSessionConfiguration)
+    model _: String,
+    configuration _: OpenAIRealtimeSessionConfiguration)
     async throws -> OpenAIRealtimeSession
   {
-      throw ProxLockServiceError.unsupportedFunction("Realtime Session")
+    throw ProxLockServiceError.unsupportedFunction("Realtime Session")
   }
   #endif
 
@@ -1681,8 +1684,6 @@ struct ProxLockOpenAIService: OpenAIService {
 
   /// The partial key for ProxLock
   private let apiKey: Authorization
-    /// The id for a this key in ProxLock.
-    public let assosiationID: String
   /// [organization](https://platform.openai.com/docs/api-reference/organization-optional)
   private let organizationID: String?
   /// Set this flag to TRUE if you need to print request events in DEBUG builds.

--- a/Sources/OpenAI/ProxLock/ProxLockService.swift
+++ b/Sources/OpenAI/ProxLock/ProxLockService.swift
@@ -1,8 +1,8 @@
 //
-//  DefaultOpenAIService.swift
+//  ProxLockService.swift
 //
 //
-//  Created by James Rochabrun on 10/17/23.
+//  Created by Morris Richman on 1/2/2026.
 //
 
 import Foundation
@@ -19,6 +19,9 @@ enum ProxLockServiceError: Error {
     }
 }
 
+/// The ProxLockOpenAIService acts nearly identically to ``DefaultOpenAIService``, but the requests it sends are processed to proxy through api.proxlock.dev at the last step. This makes maintenance a lot easier as everything is the same except for the request at its last step.
+///
+/// - Warning: ProxLock does not support WebSockets at this time. `realtimeSession` will throw an error if used.
 struct ProxLockOpenAIService: OpenAIService {
   init(
     partialKey: String,
@@ -34,7 +37,7 @@ struct ProxLockOpenAIService: OpenAIService {
   {
     self.httpClient = httpClient
     self.decoder = decoder
-      self.apiKey = .bearer(partialKey)
+      self.apiKey = .apiKey(partialKey)
       self.assosiationID = assosiationID
     self.organizationID = organizationID
     self.extraHeaders = extraHeaders

--- a/Sources/OpenAI/Public/Parameters/Realtime/OpenAIRealtimeSessionConfiguration.swift
+++ b/Sources/OpenAI/Public/Parameters/Realtime/OpenAIRealtimeSessionConfiguration.swift
@@ -1,5 +1,3 @@
-// MARK: - OpenAIRealtimeSessionConfiguration
-
 //
 //  OpenAIRealtimeSessionConfiguration.swift
 //  SwiftOpenAI
@@ -7,6 +5,8 @@
 //  Created from AIProxySwift
 //  Original: https://github.com/lzell/AIProxySwift
 //
+
+// MARK: - OpenAIRealtimeSessionConfiguration
 
 /// Realtime session configuration
 /// https://platform.openai.com/docs/api-reference/realtime-client-events/session/update#realtime-client-events/session/update-session

--- a/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
+++ b/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
@@ -98,6 +98,38 @@ public class OpenAIServiceFactory {
   }
   #endif
 
+  #if !os(Linux)
+
+  // MARK: ProxLock
+
+  /// Creates and returns an instance of `OpenAIService` for use with proxlock.dev
+  /// Use this service to protect your OpenAI API key before going to production.
+  ///
+  /// - Parameters:
+  ///   - proxLockPartialKey: The partial key provided in your ProxLock project.
+  ///                        Please see the integration guide for acquiring your key, at https://docs.proxlock.dev
+  ///
+  ///   - proxLockAssociationID: The association ID of your key in your ProxLock project
+  ///   - debugEnabled: If `true` service prints event on DEBUG builds, default to `false`.
+  ///
+  /// - Returns: A conformer of OpenAIService that proxies all requests through api.aiproxy.pro
+  public static func service(
+    proxLockPartialKey: String,
+    proxLockAssociationID: String,
+    httpClient: HTTPClient? = nil,
+    debugEnabled: Bool = false)
+    -> OpenAIService
+  {
+      let client = httpClient ?? HTTPClientFactory.createDefault()
+    return ProxLockOpenAIService(
+        partialKey: proxLockPartialKey,
+        assosiationID: proxLockAssociationID,
+        httpClient: client,
+        debugEnabled: debugEnabled
+    )
+  }
+  #endif
+
   // MARK: Custom URL
 
   /// Creates and returns an instance of `OpenAIService`.

--- a/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
+++ b/Sources/OpenAI/Public/Service/OpenAIServiceFactory.swift
@@ -120,13 +120,12 @@ public class OpenAIServiceFactory {
     debugEnabled: Bool = false)
     -> OpenAIService
   {
-      let client = httpClient ?? HTTPClientFactory.createDefault()
+    let client = httpClient ?? HTTPClientFactory.createDefault()
     return ProxLockOpenAIService(
-        partialKey: proxLockPartialKey,
-        assosiationID: proxLockAssociationID,
-        httpClient: client,
-        debugEnabled: debugEnabled
-    )
+      partialKey: proxLockPartialKey,
+      assosiationID: proxLockAssociationID,
+      httpClient: client,
+      debugEnabled: debugEnabled)
   }
   #endif
 


### PR DESCRIPTION
I have co-founded a new service called [ProxLock](https://proxlock.dev) and would like to add it to SwiftOpenAI. Unlike AIProxy.com, ProxLock does a direct proxy, meaning that the url changes and some additional validation headers are created but nothing else changes. The request stays the same. This means that it will be easier to maintain within SwiftOpenAI as OpenAI changes components of their API, because ProxLock doesn't interface or translate the request.

I hope that you all approve of the addition of ProxLock, because my goal is for it to be as simple as possible for developers to adopt.