### PR TITLE
Handle Realtime MCP event response.mcp_call.completed

### DIFF
--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/Files/AttachmentView.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/Files/AttachmentView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct AttachmentView: View {
   let fileName: String
   @Binding var actionTrigger: Bool
+
   let isLoading: Bool
 
   var body: some View {

--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ResponseAPIDemo/ResponseStreamDemoView.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/ResponseAPIDemo/ResponseStreamDemoView.swift
@@ -145,6 +145,7 @@ struct ResponseStreamDemoView: View {
 
 struct MessageBubbleView: View {
   let message: ResponseStreamProvider.ResponseMessage
+
   @Environment(\.colorScheme) var colorScheme
 
   var body: some View {

--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/SharedUI/LoadingView.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/SharedUI/LoadingView.swift
@@ -8,8 +8,6 @@
 import SwiftUI
 
 struct LoadingView: View {
-  @State private var dotsCount = 0
-
   let timer = Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()
 
   var body: some View {
@@ -28,4 +26,7 @@ struct LoadingView: View {
   func getDots() -> String {
     String(repeating: ".", count: dotsCount)
   }
+
+  @State private var dotsCount = 0
+
 }

--- a/Sources/OpenAI/Private/Audio/MicrophonePCMSampleVendorAT.swift
+++ b/Sources/OpenAI/Private/Audio/MicrophonePCMSampleVendorAT.swift
@@ -278,11 +278,11 @@ class MicrophonePCMSampleVendorAT: MicrophonePCMSampleVendor {
 /// This @RealtimeActor annotation is a lie.
 @RealtimeActor private let audioRenderCallback: AURenderCallback = {
   inRefCon,
-    ioActionFlags,
-    inTimeStamp,
-    inBusNumber,
-    inNumberFrames,
-    _ in
+  ioActionFlags,
+  inTimeStamp,
+  inBusNumber,
+  inNumberFrames,
+  _ in
   let microphonePCMSampleVendor = Unmanaged<MicrophonePCMSampleVendorAT>
     .fromOpaque(inRefCon)
     .takeUnretainedValue()

--- a/Sources/OpenAI/Private/Realtime/OpenAIRealtimeSession.swift
+++ b/Sources/OpenAI/Private/Realtime/OpenAIRealtimeSession.swift
@@ -248,16 +248,16 @@ open class OpenAIRealtimeSession {
           "Top-level fields: message=\(String(describing: topLevelMessage)), code=\(String(describing: topLevelCode)), reason=\(String(describing: topLevelReason))")
 
       continuation?.yield(.mcpListToolsFailed(fullError))
-        
+
     case "response.mcp_call.completed":
       let eventId = json["event_id"] as? String
       let itemId = json["item_id"] as? String
       let outputIndex = json["output_index"] as? Int
       continuation?.yield(.responseMcpCallCompleted(eventId: eventId, itemId: itemId, outputIndex: outputIndex))
-        
+
     case "response.mcp_call.in_progress":
       continuation?.yield(.responseMcpCallInProgress)
-        
+
     case "response.done":
       // Handle response completion (may contain errors like insufficient_quota)
       if

--- a/Sources/OpenAI/Private/Realtime/OpenAIRealtimeSession.swift
+++ b/Sources/OpenAI/Private/Realtime/OpenAIRealtimeSession.swift
@@ -248,7 +248,16 @@ open class OpenAIRealtimeSession {
           "Top-level fields: message=\(String(describing: topLevelMessage)), code=\(String(describing: topLevelCode)), reason=\(String(describing: topLevelReason))")
 
       continuation?.yield(.mcpListToolsFailed(fullError))
-
+        
+    case "response.mcp_call.completed":
+      let eventId = json["event_id"] as? String
+      let itemId = json["item_id"] as? String
+      let outputIndex = json["output_index"] as? Int
+      continuation?.yield(.responseMcpCallCompleted(eventId: eventId, itemId: itemId, outputIndex: outputIndex))
+        
+    case "response.mcp_call.in_progress":
+      continuation?.yield(.responseMcpCallInProgress)
+        
     case "response.done":
       // Handle response completion (may contain errors like insufficient_quota)
       if

--- a/Sources/OpenAI/Public/ResponseModels/Realtime/OpenAIRealtimeMessage.swift
+++ b/Sources/OpenAI/Public/ResponseModels/Realtime/OpenAIRealtimeMessage.swift
@@ -40,11 +40,11 @@ public enum OpenAIRealtimeMessage: Sendable {
   // Content part lifecycle
   case responseContentPartAdded(type: String) // "response.content_part.added"
   case responseContentPartDone(type: String, text: String?) // "response.content_part.done"
-    
+
   // MCP response
   case responseMcpCallCompleted(eventId: String?, itemId: String?, outputIndex: Int?)
   case responseMcpCallInProgress
-    
+
   /// Conversation item
   case conversationItemCreated(itemId: String, type: String, role: String?) // "conversation.item.created"
 }

--- a/Sources/OpenAI/Public/ResponseModels/Realtime/OpenAIRealtimeMessage.swift
+++ b/Sources/OpenAI/Public/ResponseModels/Realtime/OpenAIRealtimeMessage.swift
@@ -26,7 +26,6 @@ public enum OpenAIRealtimeMessage: Sendable {
   case mcpListToolsInProgress // "mcp_list_tools.in_progress"
   case mcpListToolsCompleted([String: Any]) // "mcp_list_tools.completed" with tools data
   case mcpListToolsFailed(String?) // "mcp_list_tools.failed" with error details
-
   /// Response completion with potential errors
   case responseDone(status: String, statusDetails: [String: Any]?) // "response.done"
 
@@ -41,7 +40,11 @@ public enum OpenAIRealtimeMessage: Sendable {
   // Content part lifecycle
   case responseContentPartAdded(type: String) // "response.content_part.added"
   case responseContentPartDone(type: String, text: String?) // "response.content_part.done"
-
+    
+  // MCP response
+  case responseMcpCallCompleted(eventId: String?, itemId: String?, outputIndex: Int?)
+  case responseMcpCallInProgress
+    
   /// Conversation item
   case conversationItemCreated(itemId: String, type: String, role: String?) // "conversation.item.created"
 }

--- a/Sources/OpenAI/Public/Service/OpenAIService.swift
+++ b/Sources/OpenAI/Public/Service/OpenAIService.swift
@@ -1419,9 +1419,11 @@ extension OpenAIService {
                   case .threadMessageDelta:
                     let decoded = try self.decoder.decode(MessageDeltaObject.self, from: data)
                     continuation.yield(.threadMessageDelta(decoded))
+
                   case .threadRunStepDelta:
                     let decoded = try self.decoder.decode(RunStepDeltaObject.self, from: data)
                     continuation.yield(.threadRunStepDelta(decoded))
+
                   case .threadRun:
                     // We expect a object of type "thread.run.SOME_STATE" in the data object
                     // However what we get is a `thread.run` object but we can check the status
@@ -1454,6 +1456,7 @@ extension OpenAIService {
                       }
                       #endif
                     }
+
                   default:
                     #if DEBUG
                     if debugEnabled {


### PR DESCRIPTION
# Problem
When using MCP tools with the Realtime API:
1. The model initiates an MCP call.
2. The MCP server completes successfully.
3. The Realtime API emits `response.mcp_call.completed`.
4. SwiftOpenAI logs the event as unhandled and drops it.
Because the event is not exposed to the client, applications cannot trigger a follow-up response.create call. This can lead to a stalled conversation where no `response.audio.delta` events are emitted until the user sends another input.

# Solution
This PR:
- Adds support for decoding `response.mcp_call.completed`.
- Surfaces the event through a new `OpenAIRealtimeMessage` case.
- Allows client applications to react appropriately (e.g., sending `response.create` to continue generation).
This keeps the SDK behavior consistent with other surfaced Realtime events and avoids silently discarding valid protocol messages.

# Example Usage
After this change, applications can handle MCP completion like this:
```swift 
case .responseMcpCallCompleted:
    await session.sendMessage(OpenAIRealtimeResponseCreate())
```
This enables proper continuation of assistant output (including audio streaming) after MCP tool execution.

# Compatibility
- No breaking changes.
- Existing behavior remains unchanged for users not using MCP tools.
- Adds support for an already-emitted but previously unhandled Realtime event.