### PR TITLE
Fix crash when playing assistant audio on a non-rendering engine

### DIFF
--- a/Sources/OpenAI/Private/Audio/AudioPCMPlayer.swift
+++ b/Sources/OpenAI/Private/Audio/AudioPCMPlayer.swift
@@ -93,6 +93,19 @@ final class AudioPCMPlayer {
   }
 
   public func playPCM16Audio(from base64String: String, itemID: String?) {
+    // `isRunning` alone does not prove the graph is alive: after a voice-processing stream
+    // timeout (`AUVPAggregate`, -10877) the engine reports running while its IO thread never
+    // cycles, and `AVAudioPlayerNode.play()` raises an uncatchable NSException ("player did
+    // not see an IO cycle") in that state. A valid sample time on the output node is the
+    // evidence that the render loop has actually produced cycles.
+    guard
+      audioEngine.isRunning,
+      audioEngine.outputNode.lastRenderTime?.isSampleTimeValid == true
+    else {
+      logger.warning("Dropping assistant audio: engine is not rendering IO cycles")
+      return
+    }
+
     guard let audioData = Data(base64Encoded: base64String) else {
       logger.error("Could not decode base64 string for audio playback")
       return
@@ -136,30 +149,28 @@ final class AudioPCMPlayer {
       return
     }
 
-    if audioEngine.isRunning {
-      if !hasActivePlayback || activeItemID != itemID {
-        hasActivePlayback = true
-        activeItemID = itemID
-        playbackStartSampleTime = currentSampleTime
-        scheduledFrameCount = 0
+    if !hasActivePlayback || activeItemID != itemID {
+      hasActivePlayback = true
+      activeItemID = itemID
+      playbackStartSampleTime = currentSampleTime
+      scheduledFrameCount = 0
+    }
+    scheduledFrameCount += AVAudioFramePosition(outPCMBuf.frameLength)
+    let generation = playbackGeneration
+    pendingBufferCount += 1
+    playerNode.scheduleBuffer(
+      outPCMBuf,
+      at: nil,
+      options: [],
+      completionCallbackType: .dataPlayedBack)
+    { [weak self] _ in
+      Task { @RealtimeActor [weak self] in
+        self?.didFinishBuffer(generation: generation)
       }
-      scheduledFrameCount += AVAudioFramePosition(outPCMBuf.frameLength)
-      let generation = playbackGeneration
-      pendingBufferCount += 1
-      playerNode.scheduleBuffer(
-        outPCMBuf,
-        at: nil,
-        options: [],
-        completionCallbackType: .dataPlayedBack)
-      { [weak self] _ in
-        Task { @RealtimeActor [weak self] in
-          self?.didFinishBuffer(generation: generation)
-        }
-      }
-      playerNode.play()
-      if playbackStartSampleTime == nil {
-        playbackStartSampleTime = currentSampleTime ?? 0
-      }
+    }
+    playerNode.play()
+    if playbackStartSampleTime == nil {
+      playbackStartSampleTime = currentSampleTime ?? 0
     }
   }
 


### PR DESCRIPTION
## Problem

A host app using the realtime voice stack crashed with:

```
*** Terminating app due to uncaught exception 'com.apple.coreaudio.avfaudio',
reason: 'player did not see an IO cycle.'
```

`AudioPCMPlayer.playPCM16Audio` guards on `audioEngine.isRunning` before calling `AVAudioPlayerNode.play()`, but that flag can report true while the engine's IO thread never actually cycles — the `AUVPAggregate` stream-timeout failure (`-10877`) already documented for the capture side, where the engine claims it started but the HAL stream never runs. Calling `play()` on such an engine raises an uncatchable NSException and terminates the process, and it fires as soon as the first assistant audio delta arrives — before any capture-side watchdog gets a chance to rebuild the dead graph.

## Fix

Require evidence that the render loop is actually producing cycles — a valid sample time on the engine's output node — in addition to `isRunning` before scheduling and playing:

```swift
guard
  audioEngine.isRunning,
  audioEngine.outputNode.lastRenderTime?.isSampleTimeValid == true
else {
  logger.warning("Dropping assistant audio: engine is not rendering IO cycles")
  return
}
```

On a dead engine the buffer is now dropped with a log warning instead of crashing. Since capture shares the same engine, the mic stays digitally silent in that state, so callers that watchdog for dead capture (e.g. a self-healing controller that rebuilds the graph) can recover the session.

The guard moved to the top of the method, which also skips the base64 decode and format conversion work when the engine can't play, and the old `if audioEngine.isRunning` wrapper around scheduling became redundant and was unwrapped (indentation-only change for that block).

## Testing

- `swift build` and package tests pass.
- Verified in a host app: the previously crashing path now logs the warning and the session recovers via graph rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
