### PR TITLE
Make HTTP transport types public and add PATCH/PUT methods

### DIFF
--- a/Sources/OpenAI/Private/Networking/Endpoint.swift
+++ b/Sources/OpenAI/Private/Networking/Endpoint.swift
@@ -16,6 +16,8 @@ public enum HTTPMethod: String {
   case post = "POST"
   case get = "GET"
   case delete = "DELETE"
+  case patch = "PATCH"
+  case put = "PUT"
 }
 
 // MARK: - Endpoint

--- a/Sources/OpenAI/Private/Networking/HTTPClient.swift
+++ b/Sources/OpenAI/Private/Networking/HTTPClient.swift
@@ -56,13 +56,13 @@ public struct HTTPRequest {
   }
 
   /// The URL for the request
-  var url: URL
+  public var url: URL
   /// The HTTP method for the request
-  var method: HTTPMethod
+  public var method: HTTPMethod
   /// The HTTP headers for the request
-  var headers: [String: String]
+  public var headers: [String: String]
   /// The body of the request, if any
-  var body: Data?
+  public var body: Data?
 }
 
 // MARK: - HTTPResponse
@@ -70,9 +70,9 @@ public struct HTTPRequest {
 /// Represents an HTTP response with platform-agnostic properties
 public struct HTTPResponse {
   /// The HTTP status code of the response
-  var statusCode: Int
+  public var statusCode: Int
   /// The HTTP headers in the response
-  var headers: [String: String]
+  public var headers: [String: String]
 
   public init(statusCode: Int, headers: [String: String]) {
     self.statusCode = statusCode


### PR DESCRIPTION
Makes the platform-agnostic HTTP transport layer usable from external packages:

- `HTTPRequest.url/method/headers/body` and `HTTPResponse.statusCode/headers` are now `public` (previously only the initializers were).
- `HTTPMethod` gains `.patch` and `.put`. Both adapters already pass `rawValue` straight through, so no behavior changes.

No breaking changes for existing users: the visibility change is purely additive, and nothing in the library switches exhaustively over `HTTPMethod`. Suggest shipping as a minor version bump.
