### PR TITLE
Declare Linux transport dependencies explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,16 @@ jobs:
 
   build_and_test_linux:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: swift:6.0.1-jammy
+            dependencies: locked
+          - image: swift:6.2-jammy
+            dependencies: latest
     container:
-      image: swift:6.0.1-jammy
+      image: ${{ matrix.image }}
     steps:
     - name: Install dependencies
       run: |
@@ -33,10 +41,15 @@ jobs:
     - uses: actions/checkout@v4
     - name: Get swift version
       run: swift --version
-    - name: Build
-      run: swift build -q
+    - name: Resolve current compatible dependencies
+      if: matrix.dependencies == 'latest'
+      run: swift package update
+    - name: Clean build
+      run: |
+        swift package clean
+        swift build -q --force-resolved-versions
     - name: Run tests
-      run: swift test -q
+      run: swift test -q --force-resolved-versions
 
   lint:
     runs-on: macos-latest

--- a/Examples/SwiftOpenAIExample/SwiftOpenAIExample/SharedUI/ChatDisplayMessageView.swift
+++ b/Examples/SwiftOpenAIExample/SwiftOpenAIExample/SharedUI/ChatDisplayMessageView.swift
@@ -18,17 +18,17 @@ struct ChatDisplayMessageView: View {
         case .content(let content):
           let text = content.compactMap { contentItem -> String? in
             if case .text(let text) = contentItem {
-              return text
+              text
             } else {
-              return nil
+              nil
             }
           }.first ?? ""
 
           let urls = content.compactMap { contentItem -> URL? in
             if case .imageUrl(let imageDetail) = contentItem {
-              return imageDetail.url
+              imageDetail.url
             } else {
-              return nil
+              nil
             }
           }
           VStack(alignment: .leading, spacing: 8) {

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.25.2"),
+    .package(url: "https://github.com/apple/swift-nio.git", from: "2.78.0"),
   ],
   targets: [
     // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -26,6 +27,9 @@ let package = Package(
       name: "SwiftOpenAI",
       dependencies: [
         .product(name: "AsyncHTTPClient", package: "async-http-client", condition: .when(platforms: [.linux])),
+        .product(name: "NIOCore", package: "swift-nio", condition: .when(platforms: [.linux])),
+        .product(name: "NIOFoundationCompat", package: "swift-nio", condition: .when(platforms: [.linux])),
+        .product(name: "NIOHTTP1", package: "swift-nio", condition: .when(platforms: [.linux])),
       ]),
     .testTarget(
       name: "SwiftOpenAITests",

--- a/Sources/OpenAI/Private/Audio/AudioUtils.swift
+++ b/Sources/OpenAI/Private/Audio/AudioUtils.swift
@@ -188,7 +188,7 @@ nonisolated private func isBuiltInHeadphonePort(deviceID: AudioDeviceID) -> Bool
     mElement: kAudioObjectPropertyElementMain)
 
   let err = withUnsafeMutablePointer(to: &deviceUID) { ptr -> OSStatus in
-    return AudioObjectGetPropertyData(
+    AudioObjectGetPropertyData(
       deviceID,
       &address,
       0,

--- a/Sources/OpenAI/Public/ResponseModels/Response/ResponseModel.swift
+++ b/Sources/OpenAI/Public/ResponseModels/Response/ResponseModel.swift
@@ -199,17 +199,17 @@ public struct ResponseModel: Decodable {
     let outputTextItems = output.compactMap { outputItem -> String? in
       switch outputItem {
       case .message(let message):
-        return message.content.compactMap { contentItem -> String? in
+        message.content.compactMap { contentItem -> String? in
           switch contentItem {
           case .outputText(let outputText):
-            return outputText.text
+            outputText.text
           case .refusal:
-            return nil
+            nil
           }
         }.joined()
 
       default:
-        return nil
+        nil
       }
     }
 


### PR DESCRIPTION
Linux consumers can fail to build with `no such module NIOFoundationCompat` because the transport imports SwiftNIO products without declaring them in its target dependencies. Declare the three imported products for Linux, using a version range compatible with the existing AsyncHTTPClient minimum.

Keep the existing locked-dependency Linux job and add a Swift 6.2 job that resolves current compatible dependencies. Both perform a clean library build before running tests, so cached modules cannot conceal missing dependencies. The package's Swift tools version and Apple deployment targets stay the same. Apply the current formatter's implicit-return style in three existing files so the full repository lint check passes.

Validation:
- macOS arm64, Swift 6.3: 94 tests passed.
- Linux arm64, Swift 6.2.4, freshly resolved dependencies: clean build and 92 tests passed.
- Linux arm64, Swift 6.0.1, checked-in lockfile: clean build and 92 tests passed.
