### PR TITLE
Preserve Linux streaming lines across HTTP chunks

### DIFF
--- a/Sources/OpenAI/Private/Networking/AsyncHTTPClientAdapter.swift
+++ b/Sources/OpenAI/Private/Networking/AsyncHTTPClientAdapter.swift
@@ -66,23 +66,9 @@ public class AsyncHTTPClientAdapter: HTTPClient {
       statusCode: Int(response.status.code),
       headers: convertHeaders(response.headers))
 
-    let stream = AsyncThrowingStream<String, Error> { continuation in
-      Task {
-        do {
-          for try await byteBuffer in response.body {
-            if let string = byteBuffer.getString(at: 0, length: byteBuffer.readableBytes) {
-              let lines = string.split(separator: "\n", omittingEmptySubsequences: false)
-              for line in lines {
-                continuation.yield(String(line))
-              }
-            }
-          }
-          continuation.finish()
-        } catch {
-          continuation.finish(throwing: error)
-        }
-      }
-    }
+    // HTTP body chunks are arbitrary byte ranges, not lines or UTF-8 boundaries.
+    // Keep pending bytes until a delimiter arrives; use the buffer's readable region.
+    let stream = HTTPLineStream.lines(from: response.body.map { Array($0.readableBytesView) })
 
     return (.lines(stream), httpResponse)
   }

--- a/Sources/OpenAI/Private/Networking/HTTPLineDecoder.swift
+++ b/Sources/OpenAI/Private/Networking/HTTPLineDecoder.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+// MARK: - HTTPLineDecoder
+
+/// Incremental conversion of HTTP body chunks to lines.
+struct HTTPLineDecoder {
+  mutating func append(_ bytes: [UInt8]) -> [String] {
+    var lines = [String]()
+    for byte in bytes {
+      if previousWasCR {
+        previousWasCR = false
+        if byte == 0x0A { continue }
+      }
+      if byte == 0x0A || byte == 0x0D {
+        lines.append(String(decoding: pending, as: UTF8.self))
+        pending.removeAll(keepingCapacity: true)
+        previousWasCR = byte == 0x0D
+      } else {
+        pending.append(byte)
+      }
+    }
+    return lines
+  }
+
+  mutating func finish() -> String? {
+    guard !pending.isEmpty else { return nil }
+    defer { pending.removeAll(keepingCapacity: true) }
+    return String(decoding: pending, as: UTF8.self)
+  }
+
+  private var pending = [UInt8]()
+  private var previousWasCR = false
+
+}
+
+// MARK: - HTTPLineStream
+
+/// Owns the producer task so cancelling the line consumer also cancels the HTTP body.
+enum HTTPLineStream {
+  static func lines<Source: AsyncSequence>(from chunks: Source) -> AsyncThrowingStream<String, Error>
+    where Source.Element == [UInt8]
+  {
+    AsyncThrowingStream { continuation in
+      let task = Task {
+        var decoder = HTTPLineDecoder()
+        do {
+          for try await chunk in chunks {
+            try Task.checkCancellation()
+            for line in decoder.append(chunk) {
+              if case .terminated = continuation.yield(line) { return }
+            }
+          }
+          try Task.checkCancellation()
+          if let tail = decoder.finish() { continuation.yield(tail) }
+          continuation.finish()
+        } catch {
+          continuation.finish(throwing: error)
+        }
+      }
+      continuation.onTermination = { _ in task.cancel() }
+    }
+  }
+}

--- a/Tests/OpenAITests/HTTPLineDecoderTests.swift
+++ b/Tests/OpenAITests/HTTPLineDecoderTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import SwiftOpenAI
+
+final class HTTPLineDecoderTests: XCTestCase {
+  func testJSONAndUTF8SurviveEveryPossibleNetworkSplit() {
+    let text = "data: {\"choices\":[{\"delta\":{\"content\":\"café 😀\"}}]}\n\ndata: [DONE]\n\n"
+    let bytes = Array(text.utf8)
+    let expected = ["data: {\"choices\":[{\"delta\":{\"content\":\"café 😀\"}}]}", "", "data: [DONE]", ""]
+    for split in 0...bytes.count {
+      XCTAssertEqual(decode([Array(bytes[..<split]), Array(bytes[split...])]), expected, "split \(split)")
+    }
+    XCTAssertEqual(decode(bytes.map { [$0] }), expected)
+  }
+
+  func testEmptyChunksAndLineBoundariesDoNotInventBlankLines() {
+    XCTAssertEqual(
+      decode([[], Array("data: one\n".utf8), [], Array("\ndata: two\n\n".utf8), []]),
+      ["data: one", "", "data: two", ""])
+  }
+
+  func testCRLFAcrossChunksAndBareCR() {
+    XCTAssertEqual(decode(Array("a\r\nb\rc\n\r\n".utf8).map { [$0] }), ["a", "b", "c", ""])
+  }
+
+  func testEOFReturnsOnlyThePendingLineWithoutInventingDelimiter() {
+    var decoder = HTTPLineDecoder()
+    XCTAssertEqual(decoder.append(Array("data: {\"partial\":".utf8)), [])
+    XCTAssertEqual(decoder.finish(), "data: {\"partial\":")
+    XCTAssertNil(decoder.finish())
+    XCTAssertEqual(decode([Array("complete\n".utf8)]), ["complete"])
+    XCTAssertEqual(decode([]), [])
+  }
+
+  func testStreamPreservesMalformedPayloadForCallerToReject() async throws {
+    let source = AsyncThrowingStream<[UInt8], Error> { continuation in
+      for text in ["data: {bad", " JSON}\n", "\n"] { continuation.yield(Array(text.utf8)) }
+      continuation.finish()
+    }
+    var lines = [String]()
+    for try await line in HTTPLineStream.lines(from: source) { lines.append(line) }
+    XCTAssertEqual(lines, ["data: {bad JSON}", ""])
+  }
+
+  func testConnectionFailureDoesNotFlushPartialBytesAsALine() async throws {
+    enum FixtureError: Error { case disconnected }
+    let source = AsyncThrowingStream<[UInt8], Error> { continuation in
+      continuation.yield(Array("complete\npartial".utf8))
+      continuation.finish(throwing: FixtureError.disconnected)
+    }
+    var lines = [String]()
+    do {
+      for try await line in HTTPLineStream.lines(from: source) { lines.append(line) }
+      XCTFail("Expected connection failure")
+    } catch FixtureError.disconnected { }
+    XCTAssertEqual(lines, ["complete"])
+  }
+
+  func testConsumerCancellationTerminatesSource() async throws {
+    let terminated = expectation(description: "source cancelled")
+    let received = expectation(description: "first line received")
+    let source = AsyncThrowingStream<[UInt8], Error> { continuation in
+      continuation.onTermination = { _ in terminated.fulfill() }
+      continuation.yield(Array("first\npending".utf8))
+    }
+    let consumer = Task {
+      do {
+        for try await _ in HTTPLineStream.lines(from: source) { received.fulfill() }
+      } catch { }
+    }
+    await fulfillment(of: [received], timeout: 2)
+    consumer.cancel()
+    await fulfillment(of: [terminated], timeout: 2)
+    _ = await consumer.result
+  }
+
+  private func decode(_ chunks: [[UInt8]]) -> [String] {
+    var decoder = HTTPLineDecoder()
+    var result = chunks.flatMap { decoder.append($0) }
+    if let tail = decoder.finish() { result.append(tail) }
+    return result
+  }
+
+}


### PR DESCRIPTION
Linux streaming treated arbitrary HTTP body chunks as complete lines. A JSON line or UTF-8 character split between chunks could therefore reach the consumer incomplete, and chunk boundaries could add spurious empty lines.

Buffer bytes until a real LF, CRLF or CR delimiter, retain only the pending EOF tail, read the ByteBuffer readable region, and cancel the body producer when its consumer terminates. Malformed payloads and connection errors remain errors for the caller to classify.

Validation:

- Full SDK suites: 101 tests on macOS and 99 on Linux arm64, zero failures.
- Seven new regressions cover every byte split of a JSON/UTF-8 event, one-byte/empty chunks, line boundaries, partial EOF, malformed payload forwarding, connection failure and cancellation. The original implementation fails 77 assertions in the four boundary regressions.
- Nine downstream CLI integration cases pass in disposable Linux containers with networking disabled and a scripted loopback provider. The released adapter fails three valid split-response cases; the patched adapter completes all three with exact text. Malformed input still fails, cancellation closes the connection, and each case makes one request with valid JSON output.
- Repository formatting and whitespace checks pass. No external model calls were used.
